### PR TITLE
Configure Digital Ocean deployment to run only on releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy
 on:
   release:
     types: [ published ]
-  push:
-    branches: [ trunk ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Remove push to trunk trigger from Digital Ocean deploy workflow
- Digital Ocean now deploys only on release publication
- GitHub Pages continues to deploy on merge to trunk