### PR TITLE
Remove environment protection from GitHub Pages deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -12,9 +12,6 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
- Remove environment section from github-pages workflow
- Fixes deployment rejection due to environment protection rules
- Allows trunk branch to deploy to GitHub Pages automatically