### PR TITLE
fix-url: refactor avatar URL handling to use full domain

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/IconUserViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/IconUserViewModel.kt
@@ -1,13 +1,6 @@
 package my.drivebit.viewmodels
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import my.drivebit.repositories.AvatarRepository
-import my.drivebit.utils.DEFAULT_AVATAR_PATH
 
 class IconUserViewModel(
     private val avatarRepository: AvatarRepository,

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/IconUserViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/IconUserViewModel.kt
@@ -11,14 +11,9 @@ import my.drivebit.utils.DEFAULT_AVATAR_PATH
 
 class IconUserViewModel(
     private val avatarRepository: AvatarRepository,
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
-    val avatarUrl: StateFlow<String> =
-        avatarRepository.avatarUrl.stateIn(
-            scope = coroutineScope,
-            started = SharingStarted.Lazily,
-            initialValue = DEFAULT_AVATAR_PATH,
-        )
+    val avatarUrl
+        get() = avatarRepository.avatarUrl
 
     fun refresh() {
         avatarRepository.refresh()

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/IconUserViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/IconUserViewModelTest.kt
@@ -1,12 +1,7 @@
 package my.drivebit.viewmodels
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -36,26 +31,19 @@ class IconUserViewModelTest {
                 FakeAvatarRepository().apply {
                     setAvatarUrl("https://example.com/avatar.jpg")
                 }
-            val testScope = CoroutineScope(SupervisorJob() + this.coroutineContext)
-            val viewModel = IconUserViewModel(fakeRepository, testScope)
+            val viewModel = IconUserViewModel(fakeRepository)
 
             advanceUntilIdle()
-            val url =
-                viewModel.avatarUrl
-                    .take(2)
-                    .toList()
-                    .last()
+            val url = viewModel.avatarUrl.first()
 
             assertEquals("https://example.com/avatar.jpg", url)
-            testScope.coroutineContext.cancelChildren()
         }
 
     @Test
     fun `avatarUrl should update when repository updates`() =
         runTest(StandardTestDispatcher()) {
             val fakeRepository = FakeAvatarRepository()
-            val testScope = CoroutineScope(SupervisorJob() + this.coroutineContext)
-            val viewModel = IconUserViewModel(fakeRepository, testScope)
+            val viewModel = IconUserViewModel(fakeRepository)
 
             advanceUntilIdle()
             val initialUrl = viewModel.avatarUrl.first()
@@ -66,7 +54,6 @@ class IconUserViewModelTest {
 
             val updatedUrl = viewModel.avatarUrl.first()
             assertEquals("https://example.com/new-avatar.jpg", updatedUrl)
-            testScope.coroutineContext.cancelChildren()
         }
 
     @Test
@@ -82,12 +69,10 @@ class IconUserViewModelTest {
                         refreshCalled = true
                     }
                 }
-            val testScope = CoroutineScope(SupervisorJob() + this.coroutineContext)
-            val viewModel = IconUserViewModel(fakeRepository, testScope)
+            val viewModel = IconUserViewModel(fakeRepository)
 
             viewModel.refresh()
 
             assertTrue(refreshCalled)
-            testScope.coroutineContext.cancelChildren()
         }
 }

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
@@ -43,38 +43,36 @@ internal class AvatarRepositoryImpl(
             runCatching {
                 val apiUrl = photo.getAvatar().url
 
-                // Для всех платформ преобразуем HTTP/HTTPS URL в относительный путь
-                // http://213.171.27.185:9000/publicbct/avatars/... -> /publicbct/avatars/...
-                // https://213.171.27.185:9000/publicbct/avatars/... -> /publicbct/avatars/...
-                val relativePath =
-                    when {
-                        apiUrl.startsWith("http://213.171.27.185:9000") -> {
-                            apiUrl.removePrefix("http://213.171.27.185:9000")
-                        }
-                        apiUrl.startsWith("https://213.171.27.185:9000") -> {
-                            apiUrl.removePrefix("https://213.171.27.185:9000")
-                        }
-                        apiUrl.startsWith("http://") || apiUrl.startsWith("https://") -> {
-                            // Extract path from any HTTP/HTTPS URL
-                            // Remove protocol and domain, keep path and query
-                            val withoutProtocol = apiUrl.removePrefix("http://").removePrefix("https://")
-                            val pathStart = withoutProtocol.indexOf('/')
+                // Преобразуем URL в формат для nginx проксирования через drivebit.my
+                // http://213.171.27.185:9000/publicbct/avatars/... -> https://drivebit.my/publicbct/avatars/...
+                // https://213.171.27.185:9000/publicbct/avatars/... -> https://drivebit.my/publicbct/avatars/...
+                // Это работает как для dev.drivebit.my, так и для drivebit.my (как и API запросы)
+                when {
+                    apiUrl.startsWith("http://213.171.27.185:9000") -> {
+                        val path = apiUrl.removePrefix("http://213.171.27.185:9000")
+                        "https://drivebit.my$path"
+                    }
+                    apiUrl.startsWith("https://213.171.27.185:9000") -> {
+                        val path = apiUrl.removePrefix("https://213.171.27.185:9000")
+                        "https://drivebit.my$path"
+                    }
+                    apiUrl.startsWith("http://") || apiUrl.startsWith("https://") -> {
+                        // Extract path from any HTTP/HTTPS URL and use drivebit.my domain
+                        val withoutProtocol = apiUrl.removePrefix("http://").removePrefix("https://")
+                        val pathStart = withoutProtocol.indexOf('/')
+                        val path =
                             if (pathStart >= 0) {
                                 withoutProtocol.substring(pathStart)
                             } else {
                                 "/"
                             }
-                        }
-                        else -> {
-                            // Already a relative path or unknown format
-                            apiUrl
-                        }
+                        "https://drivebit.my$path"
                     }
-                // Ensure path starts with /
-                if (relativePath.isNotEmpty() && !relativePath.startsWith("/")) {
-                    "/$relativePath"
-                } else {
-                    relativePath
+                    else -> {
+                        // Already a relative path - convert to full URL
+                        val path = if (apiUrl.startsWith("/")) apiUrl else "/$apiUrl"
+                        "https://drivebit.my$path"
+                    }
                 }
             }.getOrElse {
                 DEFAULT_AVATAR_PATH

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/AvatarRepositoryTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/AvatarRepositoryTest.kt
@@ -80,7 +80,7 @@ class AvatarRepositoryTest {
             advanceUntilIdle()
             val url = repository.avatarUrl.first()
 
-            assertEquals("/avatar.jpg", url)
+            assertEquals("https://drivebit.my/avatar.jpg", url)
         }
 
     @Test
@@ -112,7 +112,7 @@ class AvatarRepositoryTest {
             advanceUntilIdle()
 
             val updatedUrl = repository.avatarUrl.first()
-            assertEquals("/avatar.jpg", updatedUrl)
+            assertEquals("https://drivebit.my/avatar.jpg", updatedUrl)
         }
 
     @Test
@@ -124,7 +124,7 @@ class AvatarRepositoryTest {
 
             advanceUntilIdle()
             val initialUrl = repository.avatarUrl.first()
-            assertEquals("/avatar.jpg", initialUrl)
+            assertEquals("https://drivebit.my/avatar.jpg", initialUrl)
 
             storage.setLoggedIn(false)
             repository.refresh()
@@ -143,14 +143,14 @@ class AvatarRepositoryTest {
 
             advanceUntilIdle()
             val initialUrl = repository.avatarUrl.first()
-            assertEquals("/avatar1.jpg", initialUrl)
+            assertEquals("https://drivebit.my/avatar1.jpg", initialUrl)
 
             photo.avatarUrl = "https://api.example.com/avatar2.jpg"
             repository.refresh()
             advanceUntilIdle()
 
             val updatedUrl = repository.avatarUrl.first()
-            assertEquals("/avatar2.jpg", updatedUrl)
+            assertEquals("https://drivebit.my/avatar2.jpg", updatedUrl)
         }
 
     @Test
@@ -174,6 +174,6 @@ class AvatarRepositoryTest {
             advanceUntilIdle()
 
             val updatedUrl = repository.avatarUrl.first()
-            assertEquals("/new-avatar.jpg", updatedUrl)
+            assertEquals("https://drivebit.my/new-avatar.jpg", updatedUrl)
         }
 }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/MenuUserButton.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/MenuUserButton.kt
@@ -17,7 +17,7 @@ import org.koin.compose.koinInject
 @Suppress("FunctionName")
 fun MenuUserButton(onClick: () -> Unit) {
     val iconUserViewModel: IconUserViewModel = koinInject()
-    val avatarUrl by iconUserViewModel.avatarUrl.collectAsState()
+    val avatarUrl by iconUserViewModel.avatarUrl.collectAsState(null)
 
     UniversalButton(
         isSelected = false,
@@ -35,9 +35,9 @@ fun MenuUserButton(onClick: () -> Unit) {
                 }
             },
         )
-
+        val avtUrl = avatarUrl ?: return@UniversalButton
         Img(
-            src = avatarUrl,
+            src = avtUrl,
             alt = "User",
             attrs = {
                 style {

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/ProfilePage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/ProfilePage.kt
@@ -121,7 +121,7 @@ fun ProfilePage(viewModel: ProfileViewModel = koinInject()) {
                 is ProfileState.Success -> {
                     val user = currentState.user
                     val iconUserViewModel: IconUserViewModel = koinInject()
-                    val avatarUrl by iconUserViewModel.avatarUrl.collectAsState()
+                    val avatarUrl by iconUserViewModel.avatarUrl.collectAsState(null)
                     val avatarUploadViewModel: AvatarUploadViewModel = koinInject()
                     val uploadState by avatarUploadViewModel.state.collectAsState()
                     val coroutineScope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
@@ -155,11 +155,6 @@ fun ProfilePage(viewModel: ProfileViewModel = koinInject()) {
                         }
                     }
 
-                    LaunchedEffect(uploadState) {
-                        if (uploadState is AvatarUploadState.Success) {
-                        }
-                    }
-
                     Div({
                         style {
                             display(DisplayStyle.Flex)
@@ -168,19 +163,21 @@ fun ProfilePage(viewModel: ProfileViewModel = koinInject()) {
                     }) {
                         Column(gap = 8.px, marginBottom = 24.px) {
                             RowSpaceBetween {
-                                Img(
-                                    src = avatarUrl,
-                                    alt = "User",
-                                    attrs = {
-                                        style {
-                                            width(200.px)
-                                            height(200.px)
-                                            borderRadius(50.percent)
-                                            property("object-fit", "cover")
-                                            property("object-position", "top")
-                                        }
-                                    },
-                                )
+                                avatarUrl?.let {
+                                    Img(
+                                        src = it,
+                                        alt = "User",
+                                        attrs = {
+                                            style {
+                                                width(200.px)
+                                                height(200.px)
+                                                borderRadius(50.percent)
+                                                property("object-fit", "cover")
+                                                property("object-position", "top")
+                                            }
+                                        },
+                                    )
+                                }
                                 Div({
                                     style {
                                         display(DisplayStyle.Flex)


### PR DESCRIPTION
Scope: AvatarRepository, IconUserViewModel, UI components
Subject: Convert relative avatar paths to full https://drivebit.my URLs

Body: Updated AvatarRepository to generate full URLs for avatar images instead of relative