### PR TITLE
fix: update backend URLs and avatar proxy path

### DIFF
--- a/Network/README.md
+++ b/Network/README.md
@@ -5,7 +5,8 @@
 ## API Configuration
 
 - **Base URL**: `https://api.drivebit.my`
-- **API Documentation**: [http://213.171.27.185:5000/swagger/index.html](http://213.171.27.185:5000/swagger/index.html)
+- **Backend Server**: `155.212.170.94:5000`
+- **API Documentation**: [http://155.212.170.94:5000/swagger/index.html](http://155.212.170.94:5000/swagger/index.html)
 
 ## Структура
 

--- a/Network/src/commonMain/kotlin/my/drivebit/network/di/NetworkModule.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/di/NetworkModule.kt
@@ -18,8 +18,10 @@ import org.koin.dsl.module
 
 /**
  * Network module for Koin DI
- * API Base URL: http://api.drivebit.my:5000/
- * API Documentation:  https://drivebit.my/api/swagger/index.html
+ * API Base URL: https://drivebit.my/api/
+ * Backend Server: 155.212.170.94:5000
+ * API Documentation: http://155.212.170.94:5000/swagger/index.html
+ * Production API Documentation: https://drivebit.my/api/swagger/index.html
  */
 val networkModule =
     module {

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
@@ -43,9 +43,7 @@ internal class AvatarRepositoryImpl(
             runCatching {
                 val apiUrl = photo.getAvatar().url
 
-                // Преобразуем URL в формат для проксирования
-                // Для localhost используем относительный путь (webpack dev server проксирует)
-                // Для production используем полный URL через drivebit.my
+                // Извлекаем путь из URL API и преобразуем в /avatar/...
                 val path = when {
                     apiUrl.startsWith("http://155.212.170.94:9000") -> {
                         apiUrl.removePrefix("http://155.212.170.94:9000")
@@ -69,10 +67,17 @@ internal class AvatarRepositoryImpl(
                     }
                 }
                 
-                // Используем относительный путь для локальной разработки
-                // webpack dev server проксирует /publicbct/avatars/ на внешний сервер
-                // В production nginx также проксирует относительные пути
-                path
+                // Преобразуем /publicbct/avatars/... в /avatar/...
+                val avatarPath = if (path.startsWith("/publicbct/avatars/")) {
+                    path.removePrefix("/publicbct/avatars/")
+                } else if (path.startsWith("/publicbct/avatars")) {
+                    path.removePrefix("/publicbct/avatars")
+                } else {
+                    // Если путь не начинается с /publicbct/avatars/, извлекаем только имя файла
+                    path.substringAfterLast('/')
+                }
+                
+                "/avatar/$avatarPath"
             }.getOrElse {
                 DEFAULT_AVATAR_PATH
             }

--- a/SWAGGER_NOTES.md
+++ b/SWAGGER_NOTES.md
@@ -2,8 +2,9 @@
 
 ## Важно: Всегда проверяй Swagger перед реализацией API
 
-### Ссылка на Swagger
-https://drivebit.my/api/swagger/index.html
+### Ссылки на Swagger
+- **Backend Server (прямой доступ)**: http://155.212.170.94:5000/swagger/index.html
+- **Production (через nginx)**: https://drivebit.my/api/swagger/index.html
 
 ### Ключевые моменты:
 

--- a/composeApp/webpack.config.d/webpack.config.js
+++ b/composeApp/webpack.config.d/webpack.config.js
@@ -3,11 +3,14 @@ config.devServer.historyApiFallback = true;
 config.devServer.open = false;
 config.devServer.port = 8080;
 
-// Proxy для аватаров - проксируем запросы к /publicbct/avatars/ на внешний сервер
+// Proxy для аватаров - проксируем запросы к /avatar/ на внешний сервер
 config.devServer.proxy = [
     {
-        context: ['/publicbct/avatars'],
+        context: ['/avatar'],
         target: 'http://155.212.170.94:9000',
+        pathRewrite: {
+            '^/avatar': '/publicbct/avatars',
+        },
         changeOrigin: true,
         secure: false,
         logLevel: 'debug',


### PR DESCRIPTION
Scope: Network, Repositories, webpack config
Subject: Update backend server URLs and avatar proxy configuration

Body: Changed backend server IP from 213.171.27.185 to 155.212.170.94 in Network module and documentation. Updated avatar repository to handle new URL structure and modified webpack proxy to map /avatar to /publicbct/avatars.