### PR TITLE
fix-icons-second

### DIFF
--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/AvatarRepository.kt
@@ -77,7 +77,8 @@ internal class AvatarRepositoryImpl(
                     path.substringAfterLast('/')
                 }
                 
-                "/avatar/$avatarPath"
+                // Используем абсолютный URL как для API, чтобы работать на любом домене
+                "https://drivebit.my/avatar/$avatarPath"
             }.getOrElse {
                 DEFAULT_AVATAR_PATH
             }


### PR DESCRIPTION
fix(repository): use absolute URL for avatar API

Updated AvatarRepository to use an absolute URL for avatar paths to ensure compatibility across different domains.