### PR TITLE
Мои сделки: иконка, подтверждение/отклонение

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -26,7 +26,7 @@ This is a Kotlin Multiplatform project for Drivebit mobile clients targeting And
 - iOS: Open `iosApp/` in Xcode
 
 ## Server Access
-- SSH: `ssh root@143.198.69.242`
+- SSH: `ssh root@155.212.170.94`
 
 ## Development Workflow
 - No need to run full checks locally - push to CI instead

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/resources/ImagePaths.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/resources/ImagePaths.kt
@@ -5,6 +5,7 @@ object ImagePaths {
     const val BACKGROUNDS_HERO_BG_JPG = "images/backgrounds/hero-bg.jpg"
     const val BUTTER_BOOKING_SVG = "images/butter/booking.svg"
     const val BUTTER_CAR_ICON_SVG = "images/butter/car-icon.svg"
+    const val BUTTER_DEALS_SVG = "images/butter/deals.svg"
     const val BUTTER_DOCS_SVG = "images/butter/docs.svg"
     const val BUTTER_LOGOUT_SVG = "images/butter/logout.svg"
     const val FILTER_MAIN_ADMISSION_SVG = "images/filter-main/admission.svg"

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
@@ -85,7 +85,7 @@ private val myBookings =
 
 private val myDeals =
     ButterModel(
-        iconUrl = ImagePaths.BUTTER_BOOKING_SVG,
+        iconUrl = ImagePaths.BUTTER_DEALS_SVG,
         text = "Мои сделки",
         onClick = {},
     )

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
@@ -83,6 +83,13 @@ private val myBookings =
         onClick = {},
     )
 
+private val myDeals =
+    ButterModel(
+        iconUrl = ImagePaths.BUTTER_BOOKING_SVG,
+        text = "Мои сделки",
+        onClick = {},
+    )
+
 private val logout =
     ButterModel(
         iconUrl = ImagePaths.BUTTER_LOGOUT_SVG,
@@ -136,6 +143,7 @@ class ButterViewModelImpl(
                         add(profile.copy(onClick = { close() }))
                         add(myDocuments.copy(onClick = { close() }))
                         add(myBookings.copy(onClick = { close() }))
+                        add(myDeals.copy(onClick = { close() }))
                     } else {
                         add(login.copy(onClick = { close() }))
                         add(registr.copy(onClick = { close() }))

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
@@ -1,0 +1,126 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import my.drivebit.network.services.Booking
+import my.drivebit.network.services.BookingDTO
+import my.drivebit.utils.safeLaunchWithErrorHandler
+
+interface MyBookingsAsOwnerViewModel {
+    val bookings: StateFlow<List<BookingDTO>>
+    val isLoading: StateFlow<Boolean>
+    val error: StateFlow<String?>
+    val actionInProgress: StateFlow<Set<String>>
+
+    fun loadBookings()
+    fun refreshBookings()
+    fun confirmBooking(bookingId: String)
+    fun declineBooking(bookingId: String)
+}
+
+class MyBookingsAsOwnerViewModelImpl(
+    private val booking: Booking,
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : MyBookingsAsOwnerViewModel {
+    private val _bookings = MutableStateFlow<List<BookingDTO>>(emptyList())
+    override val bookings: StateFlow<List<BookingDTO>> = _bookings.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    override val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _actionInProgress = MutableStateFlow<Set<String>>(emptySet())
+    override val actionInProgress: StateFlow<Set<String>> = _actionInProgress.asStateFlow()
+
+    override fun loadBookings() {
+        if (_isLoading.value) return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { _isLoading.value },
+            setLoading = { _isLoading.value = it },
+            setError = { _error.value = it },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось загрузить сделки",
+                )
+            },
+        ) {
+            val result = booking.getMyAsOwner()
+            _bookings.value = result
+        }
+    }
+
+    override fun refreshBookings() {
+        coroutineScope.launch {
+            runCatching {
+                val result = booking.getMyAsOwner()
+                _bookings.value = result
+                _error.value = null
+            }
+        }
+    }
+
+    override fun confirmBooking(bookingId: String) {
+        if (bookingId in _actionInProgress.value) return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { false },
+            setLoading = { },
+            setError = { _error.value = it },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось подтвердить сделку",
+                )
+            },
+        ) {
+            _actionInProgress.update { it + bookingId }
+            try {
+                val updated = booking.confirmAsOwner(bookingId)
+                _bookings.update { list ->
+                    list.map { if (it.id == bookingId) updated else it }
+                }
+            } finally {
+                _actionInProgress.update { it - bookingId }
+            }
+        }
+    }
+
+    override fun declineBooking(bookingId: String) {
+        if (bookingId in _actionInProgress.value) return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { false },
+            setLoading = { },
+            setError = { _error.value = it },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось отклонить сделку",
+                )
+            },
+        ) {
+            _actionInProgress.update { it + bookingId }
+            try {
+                val updated = booking.declineAsOwner(bookingId)
+                _bookings.update { list ->
+                    list.map { if (it.id == bookingId) updated else it }
+                }
+            } finally {
+                _actionInProgress.update { it - bookingId }
+            }
+        }
+    }
+}

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
@@ -19,8 +19,11 @@ interface MyBookingsAsOwnerViewModel {
     val actionInProgress: StateFlow<Set<String>>
 
     fun loadBookings()
+
     fun refreshBookings()
+
     fun confirmBooking(bookingId: String)
+
     fun declineBooking(bookingId: String)
 }
 
@@ -87,10 +90,9 @@ class MyBookingsAsOwnerViewModelImpl(
         ) {
             _actionInProgress.update { it + bookingId }
             try {
-                val updated = booking.confirmAsOwner(bookingId)
-                _bookings.update { list ->
-                    list.map { if (it.id == bookingId) updated else it }
-                }
+                booking.confirmAsOwner(bookingId)
+                val result = booking.getMyAsOwner()
+                _bookings.value = result
             } finally {
                 _actionInProgress.update { it - bookingId }
             }
@@ -114,10 +116,9 @@ class MyBookingsAsOwnerViewModelImpl(
         ) {
             _actionInProgress.update { it + bookingId }
             try {
-                val updated = booking.declineAsOwner(bookingId)
-                _bookings.update { list ->
-                    list.map { if (it.id == bookingId) updated else it }
-                }
+                booking.declineAsOwner(bookingId)
+                val result = booking.getMyAsOwner()
+                _bookings.value = result
             } finally {
                 _actionInProgress.update { it - bookingId }
             }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/RentViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/RentViewModel.kt
@@ -60,7 +60,17 @@ class RentViewModelImpl(
     override fun setStartDate(date: String?) {
         _state.update {
             if (it is RentState.Book) {
-                it.copy(startDate = date, showStartDateError = false)
+                val endDate =
+                    when {
+                        date == null -> null
+                        it.endDate != null -> {
+                            val startDay = date.take(10)
+                            val endDay = it.endDate.take(10)
+                            if (endDay <= startDay) null else it.endDate
+                        }
+                        else -> it.endDate
+                    }
+                it.copy(startDate = date, endDate = endDate, showStartDateError = false)
             } else {
                 it
             }
@@ -82,7 +92,12 @@ class RentViewModelImpl(
     override fun onBookClick() {
         val current = _state.value as? RentState.Book ?: return
         val showStartDateError = current.startDate.isNullOrBlank()
-        val showEndDateError = current.endDate.isNullOrBlank()
+        val endDateBlank = current.endDate.isNullOrBlank()
+        val endDateTooEarly =
+            !endDateBlank &&
+                current.startDate != null &&
+                current.endDate!!.take(10) <= current.startDate.take(10)
+        val showEndDateError = endDateBlank || endDateTooEarly
         _state.update {
             if (it is RentState.Book) {
                 it.copy(

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
@@ -46,6 +46,8 @@ import my.drivebit.viewmodels.IconUserViewModel
 import my.drivebit.viewmodels.MainContentViewModel
 import my.drivebit.viewmodels.MainContentViewModelImpl
 import my.drivebit.viewmodels.MapViewModel
+import my.drivebit.viewmodels.MyBookingsAsOwnerViewModel
+import my.drivebit.viewmodels.MyBookingsAsOwnerViewModelImpl
 import my.drivebit.viewmodels.MyBookingsAsRenterViewModel
 import my.drivebit.viewmodels.MyBookingsAsRenterViewModelImpl
 import my.drivebit.viewmodels.MyCarsViewModel
@@ -275,6 +277,12 @@ val commonViewModelsModule: Module =
 
         single<MyBookingsAsRenterViewModel> {
             MyBookingsAsRenterViewModelImpl(
+                booking = get(),
+            )
+        }
+
+        single<MyBookingsAsOwnerViewModel> {
+            MyBookingsAsOwnerViewModelImpl(
                 booking = get(),
             )
         }

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
@@ -26,6 +26,12 @@ private class FakeBooking(
 
     override suspend fun getMyAsRenter() = throw NotImplementedError()
 
+    override suspend fun getMyAsOwner() = throw NotImplementedError()
+
+    override suspend fun confirmAsOwner(bookingId: String) {}
+
+    override suspend fun declineAsOwner(bookingId: String) {}
+
     override suspend fun createAsRenter(request: my.drivebit.network.services.CreateBookingRequest) =
         my.drivebit.network.services.BookingDTO(
             id = "booking-1",

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
@@ -21,12 +21,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
-import kotlinx.coroutines.delay
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import kotlinx.coroutines.delay
 import my.drivebit.network.services.BookingDTO
 import my.drivebit.ui.icons.Icons
 import my.drivebit.ui.theme.DrivebitTheme
@@ -130,8 +130,9 @@ internal fun DealItemCard(
             .joinToString(" ")
             .ifBlank { "Автомобиль" }
     val dateRange = "${booking.startAt.take(10)} — ${booking.endAt.take(10)}"
-    val canConfirmOrDecline = booking.status.equals("Pending", ignoreCase = true) ||
-        booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
+    val canConfirmOrDecline =
+        booking.status.equals("Pending", ignoreCase = true) ||
+            booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
 
     Card(
         modifier = Modifier.fillMaxWidth(),

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
@@ -40,7 +41,7 @@ object InboxTab : Tab {
             return TabOptions(
                 index = 3u,
                 title = "Мои сделки",
-                icon = rememberVectorPainter(Icons.InboxIcon),
+                icon = rememberVectorPainter(Icons.DealsIcon),
             )
         }
 
@@ -54,6 +55,10 @@ object InboxTab : Tab {
 
         LaunchedEffect(Unit) {
             viewModel.loadBookings()
+            while (true) {
+                delay(30_000)
+                viewModel.refreshBookings()
+            }
         }
 
         Column(

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
@@ -2,20 +2,36 @@ package my.drivebit.mobile.screens.main.tabs
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import my.drivebit.network.services.BookingDTO
 import my.drivebit.ui.icons.Icons
 import my.drivebit.ui.theme.DrivebitTheme
+import my.drivebit.viewmodels.MyBookingsAsOwnerViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.koinInject
 
 object InboxTab : Tab {
     override val options: TabOptions
@@ -23,26 +39,154 @@ object InboxTab : Tab {
         get() {
             return TabOptions(
                 index = 3u,
-                title = "Входящие",
+                title = "Мои сделки",
                 icon = rememberVectorPainter(Icons.InboxIcon),
             )
         }
 
     @Composable
     override fun Content() {
+        val viewModel: MyBookingsAsOwnerViewModel = koinInject()
+        val bookings by viewModel.bookings.collectAsState()
+        val isLoading by viewModel.isLoading.collectAsState()
+        val error by viewModel.error.collectAsState()
+        val actionInProgress by viewModel.actionInProgress.collectAsState()
+
+        LaunchedEffect(Unit) {
+            viewModel.loadBookings()
+        }
+
         Column(
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
         ) {
             Text(
-                text = "Входящие",
+                text = "Мои сделки",
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+            Spacer(modifier = Modifier.height(16.dp))
+            when {
+                isLoading -> {
+                    Column(
+                        modifier = Modifier.fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> {
+                    Text(
+                        text = error ?: "Ошибка",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+                bookings.isEmpty() -> {
+                    Text(
+                        text = "У вас пока нет заявок на аренду",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                else -> {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(bookings, key = { it.id }) { booking ->
+                            DealItemCard(
+                                booking = booking,
+                                isActionInProgress = booking.id in actionInProgress,
+                                onConfirm = { viewModel.confirmBooking(booking.id) },
+                                onDecline = { viewModel.declineBooking(booking.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DealItemCard(
+    booking: BookingDTO,
+    isActionInProgress: Boolean,
+    onConfirm: () -> Unit,
+    onDecline: () -> Unit,
+) {
+    val renterName = booking.renterName?.takeIf { it.isNotBlank() } ?: "Арендатор"
+    val carName =
+        listOfNotNull(booking.carBrandName, booking.carModelName)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { "Автомобиль" }
+    val dateRange = "${booking.startAt.take(10)} — ${booking.endAt.take(10)}"
+    val canConfirmOrDecline = booking.status.equals("Pending", ignoreCase = true) ||
+        booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = renterName,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = carName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = dateRange,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${booking.totalAmount.toInt()} ₽",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = booking.status,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (canConfirmOrDecline) {
+                Spacer(modifier = Modifier.height(12.dp))
+                if (isActionInProgress) {
+                    Text(
+                        text = "Обработка...",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Button(
+                            onClick = onConfirm,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text("Подтвердить")
+                        }
+                        OutlinedButton(
+                            onClick = onDecline,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text("Отклонить")
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Network/src/commonMain/kotlin/my/drivebit/network/HttpResponseExtensions.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/HttpResponseExtensions.kt
@@ -48,6 +48,31 @@ suspend inline fun <reified T> HttpResponse.parseResponse(json: Json = defaultJs
     return json.decodeFromString<T>(bodyString)
 }
 
+suspend fun HttpResponse.consumeResponse() {
+    val bodyString = bodyAsText()
+    if (!status.isSuccess()) {
+        val errorMessage =
+            runCatching {
+                val trimmedBody = bodyString.trim()
+                if (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) {
+                    val errorResponse = defaultJson.decodeFromString<ValidationErrorResponse>(trimmedBody)
+                    val errorMessages = errorResponse.errors?.flatMap { (_, messages) -> messages } ?: emptyList()
+                    when {
+                        errorMessages.isNotEmpty() -> errorMessages.joinToString(". ")
+                        errorResponse.error != null -> errorResponse.error
+                        errorResponse.title != null -> errorResponse.title
+                        else -> trimmedBody.trim('"').trim()
+                    }
+                } else {
+                    trimmedBody.trim('"').trim()
+                }
+            }.getOrElse {
+                bodyString.trim('"').trim()
+            }
+        throw NetworkException(status, errorMessage)
+    }
+}
+
 class NetworkException(
     val statusCode: HttpStatusCode,
     override val message: String,

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -3,6 +3,7 @@ package my.drivebit.network.services
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -104,13 +105,13 @@ class BookingImpl(
 
     override suspend fun confirmAsOwner(bookingId: String): BookingDTO {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/confirm"
-        val response = authorizedHttpClient.post(url) { }
+        val response = authorizedHttpClient.put(url) { }
         return response.parseResponse()
     }
 
     override suspend fun declineAsOwner(bookingId: String): BookingDTO {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/decline"
-        val response = authorizedHttpClient.post(url) { }
+        val response = authorizedHttpClient.put(url) { }
         return response.parseResponse()
     }
 }

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -15,7 +15,13 @@ interface Booking {
 
     suspend fun getMyAsRenter(): List<BookingDTO>
 
+    suspend fun getMyAsOwner(): List<BookingDTO>
+
     suspend fun createAsRenter(request: CreateBookingRequest): BookingDTO
+
+    suspend fun confirmAsOwner(bookingId: String): BookingDTO
+
+    suspend fun declineAsOwner(bookingId: String): BookingDTO
 }
 
 @Serializable
@@ -80,6 +86,12 @@ class BookingImpl(
         return response.parseResponse()
     }
 
+    override suspend fun getMyAsOwner(): List<BookingDTO> {
+        val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/list"
+        val response = authorizedHttpClient.get(url)
+        return response.parseResponse()
+    }
+
     override suspend fun createAsRenter(request: CreateBookingRequest): BookingDTO {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-renter"
         val response =
@@ -87,6 +99,18 @@ class BookingImpl(
                 contentType(ContentType.Application.Json)
                 setBody(request)
             }
+        return response.parseResponse()
+    }
+
+    override suspend fun confirmAsOwner(bookingId: String): BookingDTO {
+        val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/confirm"
+        val response = authorizedHttpClient.post(url) { }
+        return response.parseResponse()
+    }
+
+    override suspend fun declineAsOwner(bookingId: String): BookingDTO {
+        val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/decline"
+        val response = authorizedHttpClient.post(url) { }
         return response.parseResponse()
     }
 }

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -9,6 +9,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
 import my.drivebit.network.DEFAULT_BASE_URL
+import my.drivebit.network.consumeResponse
 import my.drivebit.network.parseResponse
 
 interface Booking {
@@ -20,9 +21,9 @@ interface Booking {
 
     suspend fun createAsRenter(request: CreateBookingRequest): BookingDTO
 
-    suspend fun confirmAsOwner(bookingId: String): BookingDTO
+    suspend fun confirmAsOwner(bookingId: String)
 
-    suspend fun declineAsOwner(bookingId: String): BookingDTO
+    suspend fun declineAsOwner(bookingId: String)
 }
 
 @Serializable
@@ -103,15 +104,15 @@ class BookingImpl(
         return response.parseResponse()
     }
 
-    override suspend fun confirmAsOwner(bookingId: String): BookingDTO {
+    override suspend fun confirmAsOwner(bookingId: String) {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/confirm"
         val response = authorizedHttpClient.put(url) { }
-        return response.parseResponse()
+        response.consumeResponse()
     }
 
-    override suspend fun declineAsOwner(bookingId: String): BookingDTO {
+    override suspend fun declineAsOwner(bookingId: String) {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/decline"
         val response = authorizedHttpClient.put(url) { }
-        return response.parseResponse()
+        response.consumeResponse()
     }
 }

--- a/UI-Components/src/commonMain/kotlin/my/drivebit/ui/icons/Icons.kt
+++ b/UI-Components/src/commonMain/kotlin/my/drivebit/ui/icons/Icons.kt
@@ -106,6 +106,59 @@ object Icons {
                     )
                 }.build()
 
+    val DealsIcon: ImageVector
+        get() =
+            ImageVector
+                .Builder(
+                    name = "deals",
+                    defaultWidth = 24.dp,
+                    defaultHeight = 24.dp,
+                    viewportWidth = 48f,
+                    viewportHeight = 48f,
+                ).apply {
+                    path(
+                        fill = null,
+                        strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
+                        strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
+                        strokeLineWidth = 1.5f,
+                        pathBuilder = {
+                            moveTo(18.52f, 30.88f)
+                            cubicTo(19.6f, 32.28f, 20.95f, 32.8f, 22.83f, 32.8f)
+                            horizontalLineTo(25.44f)
+                            cubicTo(27.86f, 32.8f, 29.83f, 30.83f, 29.83f, 28.41f)
+                            horizontalLineTo(29.83f)
+                            cubicTo(29.83f, 26f, 27.86f, 24f, 25.44f, 24f)
+                            horizontalLineTo(22.56f)
+                            cubicTo(20.14f, 24f, 18.17f, 22f, 18.17f, 19.61f)
+                            horizontalLineTo(18.17f)
+                            cubicTo(18.17f, 17.19f, 20.14f, 15.21f, 22.56f, 15.21f)
+                            horizontalLineTo(25.16f)
+                            cubicTo(27.09f, 15.21f, 28.44f, 15.73f, 29.52f, 17.14f)
+                        },
+                    )
+                    path(
+                        fill = null,
+                        strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
+                        strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
+                        strokeLineWidth = 1.5f,
+                        pathBuilder = {
+                            moveTo(24f, 13f)
+                            lineTo(24f, 35f)
+                        },
+                    )
+                    path(
+                        fill = null,
+                        strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
+                        strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
+                        strokeLineWidth = 1.5f,
+                        pathBuilder = {
+                            moveTo(45.5f, 24f)
+                            arcTo(21.5f, 21.5f, 0f, true, true, 2.5f, 24f)
+                            arcTo(21.5f, 21.5f, 0f, true, true, 45.5f, 24f)
+                        },
+                    )
+                }.build()
+
     val MoreIcon: ImageVector
         get() =
             ImageVector

--- a/UI-Components/src/commonMain/kotlin/my/drivebit/ui/icons/Icons.kt
+++ b/UI-Components/src/commonMain/kotlin/my/drivebit/ui/icons/Icons.kt
@@ -122,26 +122,6 @@ object Icons {
                         strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
                         strokeLineWidth = 1.5f,
                         pathBuilder = {
-                            moveTo(18.52f, 30.88f)
-                            cubicTo(19.6f, 32.28f, 20.95f, 32.8f, 22.83f, 32.8f)
-                            horizontalLineTo(25.44f)
-                            cubicTo(27.86f, 32.8f, 29.83f, 30.83f, 29.83f, 28.41f)
-                            horizontalLineTo(29.83f)
-                            cubicTo(29.83f, 26f, 27.86f, 24f, 25.44f, 24f)
-                            horizontalLineTo(22.56f)
-                            cubicTo(20.14f, 24f, 18.17f, 22f, 18.17f, 19.61f)
-                            horizontalLineTo(18.17f)
-                            cubicTo(18.17f, 17.19f, 20.14f, 15.21f, 22.56f, 15.21f)
-                            horizontalLineTo(25.16f)
-                            cubicTo(27.09f, 15.21f, 28.44f, 15.73f, 29.52f, 17.14f)
-                        },
-                    )
-                    path(
-                        fill = null,
-                        strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
-                        strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
-                        strokeLineWidth = 1.5f,
-                        pathBuilder = {
                             moveTo(24f, 13f)
                             lineTo(24f, 35f)
                         },
@@ -155,6 +135,20 @@ object Icons {
                             moveTo(45.5f, 24f)
                             arcTo(21.5f, 21.5f, 0f, true, true, 2.5f, 24f)
                             arcTo(21.5f, 21.5f, 0f, true, true, 45.5f, 24f)
+                        },
+                    )
+                    path(
+                        fill = null,
+                        strokeLineCap = androidx.compose.ui.graphics.StrokeCap.Round,
+                        strokeLineJoin = androidx.compose.ui.graphics.StrokeJoin.Round,
+                        strokeLineWidth = 1.5f,
+                        pathBuilder = {
+                            moveTo(24f, 10f)
+                            lineTo(24f, 38f)
+                            moveTo(20f, 21f)
+                            quadTo(24f, 18f, 28f, 21f)
+                            quadTo(24f, 24f, 20f, 27f)
+                            quadTo(24f, 30f, 28f, 27f)
                         },
                     )
                 }.build()

--- a/composeApp/src/commonMain/resources/images/butter/deals.svg
+++ b/composeApp/src/commonMain/resources/images/butter/deals.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<style>.d{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;}</style>
+</defs>
+<g>
+<path class="d" d="m18.5204,30.8768c1.0789,1.4046,2.4317,1.9277,4.3138,1.9277h2.6047c2.424,0,4.389-1.9693,4.389-4.3985h0c0-2.4292-1.965-4.3985-4.389-4.3985h-2.878c-2.424,0-4.389-1.9693-4.389-4.3985h0c0-2.4292,1.965-4.3985,4.389-4.3985h2.6047c1.8821,0,3.235.5232,4.3138,1.9277"/>
+<line class="d" x1="24" y1="34.9962" x2="24" y2="13.0038"/>
+</g>
+<circle class="d" cx="24" cy="24" r="21.5"/>
+</svg>

--- a/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
@@ -30,6 +30,7 @@ import my.drivebit.screens.ListYourCarPage
 import my.drivebit.screens.LoginPage
 import my.drivebit.screens.MyBookingsPage
 import my.drivebit.screens.MyCarsPage
+import my.drivebit.screens.MyDealsPage
 import my.drivebit.screens.OtpVerificationPage
 import my.drivebit.screens.DocumentsPage
 import my.drivebit.screens.ProductionYearInputPage
@@ -99,6 +100,14 @@ actual fun App() {
                     val storage: Storage = koinInject()
                     if (storage.isLogined()) {
                         MyBookingsPage()
+                    } else {
+                        window.location.href = "/"
+                    }
+                }
+                currentPath.startsWith("/my-deals") -> {
+                    val storage: Storage = koinInject()
+                    if (storage.isLogined()) {
+                        MyDealsPage()
                     } else {
                         window.location.href = "/"
                     }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/ButterMenu.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/ButterMenu.kt
@@ -96,6 +96,11 @@ fun ButterMenu() {
                                         butterViewModel.close()
                                         navigationController?.navigateTo("/my-bookings")
                                     })
+                                "Мои сделки" ->
+                                    item.copy(onClick = {
+                                        butterViewModel.close()
+                                        navigationController?.navigateTo("/my-deals")
+                                    })
                                 else -> item
                             }
                         },

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
@@ -7,17 +7,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import my.drivebit.utils.addDays
 import my.drivebit.design.CSSColors
 import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
 import my.drivebit.navigation.LocalNavigationController
 import my.drivebit.network.services.CarBookingItem
+import my.drivebit.utils.addDays
 import my.drivebit.utils.parseDisabledDatesFromBookings
 import my.drivebit.viewmodels.ButtonState
 import my.drivebit.viewmodels.DateFieldViewModel
@@ -29,6 +28,7 @@ import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Img
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
+import kotlin.time.Duration.Companion.hours
 
 @Composable
 @Suppress("FunctionName")
@@ -65,7 +65,9 @@ fun CarBook(
         startDateState.date?.take(10)?.let { str ->
             if (str.length == 10) {
                 runCatching { addDays(LocalDate.parse(str), 1).toString() }.getOrNull()
-            } else null
+            } else {
+                null
+            }
         } ?: null
 
     LaunchedEffect(bookState.startDate) {
@@ -284,7 +286,11 @@ private fun CarBookDateField(
 
 private fun formatStartAt(date: String): String {
     val selectedDate = LocalDate.parse(date.take(10))
-    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    val today =
+        Clock.System
+            .now()
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .date
     return if (selectedDate == today) {
         (Clock.System.now() + 1.hours).toString()
     } else {

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
@@ -7,7 +7,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import my.drivebit.utils.addDays
 import my.drivebit.design.CSSColors
 import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
@@ -56,6 +61,13 @@ fun CarBook(
     val startDateState by startDateViewModel.state.collectAsState()
     val endDateState by endDateViewModel.state.collectAsState()
 
+    val endDateMinDate =
+        startDateState.date?.take(10)?.let { str ->
+            if (str.length == 10) {
+                runCatching { addDays(LocalDate.parse(str), 1).toString() }.getOrNull()
+            } else null
+        } ?: null
+
     LaunchedEffect(bookState.startDate) {
         bookState.startDate?.let { iso ->
             val datePart = iso.take(10)
@@ -63,9 +75,11 @@ fun CarBook(
         }
     }
     LaunchedEffect(bookState.endDate) {
-        bookState.endDate?.let { iso ->
-            val datePart = iso.take(10)
+        if (bookState.endDate != null) {
+            val datePart = bookState.endDate!!.take(10)
             if (datePart.length == 10) endDateViewModel.setDate(datePart)
+        } else {
+            endDateViewModel.setDate(null)
         }
     }
 
@@ -88,14 +102,14 @@ fun CarBook(
                 viewModel = startDateViewModel,
                 showError = bookState.showStartDateError,
                 onDateChanged = { date ->
-                    viewModel.setStartDate(if (date != null) "${date}T10:00:00Z" else null)
+                    viewModel.setStartDate(if (date != null) formatStartAt(date) else null)
                 },
             )
             CarBookDateField(
                 label = "Дата окончания",
                 actionLabel = "по",
                 viewModel = endDateViewModel,
-                minDate = startDateState.date,
+                minDate = endDateMinDate,
                 showError = bookState.showEndDateError,
                 enabled = startDateState.date != null,
                 onDateChanged = { date ->
@@ -164,7 +178,7 @@ fun CarBook(
                     .take(10),
             disabledDates = disabledDates,
             onDateChanged = { date ->
-                viewModel.setStartDate(if (date != null) "${date}T10:00:00Z" else null)
+                viewModel.setStartDate(if (date != null) formatStartAt(date) else null)
             },
         )
     }
@@ -172,7 +186,7 @@ fun CarBook(
         BookingDatePickerDialog(
             label = "Дата окончания",
             viewModel = endDateViewModel,
-            minDate = startDateState.date,
+            minDate = endDateMinDate,
             disabledDates = disabledDates,
             onDateChanged = { date ->
                 viewModel.setEndDate(if (date != null) "${date}T18:00:00Z" else null)
@@ -265,6 +279,16 @@ private fun CarBookDateField(
         }) {
             Text("Выберите дату")
         }
+    }
+}
+
+private fun formatStartAt(date: String): String {
+    val selectedDate = LocalDate.parse(date.take(10))
+    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    return if (selectedDate == today) {
+        (Clock.System.now() + 1.hours).toString()
+    } else {
+        "${date}T10:00:00Z"
     }
 }
 

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
@@ -111,8 +111,9 @@ private fun DealItemCard(
             "${mapIso8601ToDateString(booking.createdAt)}, в ${mapIso8601ToTimeString(booking.createdAt)}"
         }.getOrElse { booking.createdAt }
     val relativeTime = runCatching { formatRelativeTime(Instant.parse(booking.createdAt)) }.getOrElse { "" }
-    val canConfirmOrDecline = booking.status.equals("Pending", ignoreCase = true) ||
-        booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
+    val canConfirmOrDecline =
+        booking.status.equals("Pending", ignoreCase = true) ||
+            booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
 
     Column(
         gap = 16.px,

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
@@ -1,0 +1,291 @@
+package my.drivebit.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import kotlinx.coroutines.delay
+import kotlinx.datetime.Instant
+import my.drivebit.components.CenteredFormContainer
+import my.drivebit.components.Column
+import my.drivebit.components.FormSection
+import my.drivebit.components.Loader
+import my.drivebit.components.PageHeader
+import my.drivebit.components.PageWithLogo
+import my.drivebit.components.Row
+import my.drivebit.components.TextError
+import my.drivebit.components.TextSmallBodyGray
+import my.drivebit.components.TextSmartHeader
+import my.drivebit.design.CSSColors
+import my.drivebit.network.services.BookingDTO
+import my.drivebit.utils.formatRelativeTime
+import my.drivebit.utils.mapIso8601ToDateString
+import my.drivebit.utils.mapIso8601ToTimeString
+import my.drivebit.viewmodels.MyBookingsAsOwnerViewModel
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.Button
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+import org.koin.compose.koinInject
+
+@Composable
+fun MyDealsPage() {
+    val viewModel: MyBookingsAsOwnerViewModel = koinInject()
+    val bookings by viewModel.bookings.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val actionInProgress by viewModel.actionInProgress.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadBookings()
+        while (true) {
+            delay(30_000)
+            viewModel.refreshBookings()
+        }
+    }
+
+    PageWithLogo {
+        CenteredFormContainer {
+            PageHeader {
+                TextSmartHeader("Мои сделки (${bookings.size})")
+            }
+
+            FormSection {
+                when {
+                    isLoading -> Loader()
+                    error != null -> TextError(error ?: "Ошибка")
+                    bookings.isEmpty() -> {
+                        Div({
+                            style {
+                                textAlign("center")
+                                padding(32.px)
+                                color(CSSColors.Gray600)
+                            }
+                        }) {
+                            Text("У вас пока нет заявок на аренду")
+                        }
+                    }
+                    else -> {
+                        Column(gap = 16.px, modifier = { width(100.percent) }) {
+                            bookings.forEach { booking ->
+                                DealItemCard(
+                                    booking = booking,
+                                    isActionInProgress = booking.id in actionInProgress,
+                                    onConfirm = { viewModel.confirmBooking(booking.id) },
+                                    onDecline = { viewModel.declineBooking(booking.id) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DealItemCard(
+    booking: BookingDTO,
+    isActionInProgress: Boolean,
+    onConfirm: () -> Unit,
+    onDecline: () -> Unit,
+) {
+    val renterName = booking.renterName?.takeIf { it.isNotBlank() } ?: "Арендатор"
+    val carName =
+        listOfNotNull(booking.carBrandName, booking.carModelName)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { "Автомобиль" }
+    val shortId = booking.id.takeLast(6)
+    val durationHours =
+        runCatching {
+            val start = Instant.parse(booking.startAt)
+            val end = Instant.parse(booking.endAt)
+            ((end.epochSeconds - start.epochSeconds) / 3600).toInt()
+        }.getOrElse { 0 }
+    val periodStart = runCatching { mapIso8601ToDateString(booking.startAt) }.getOrElse { booking.startAt.take(10) }
+    val periodEnd = runCatching { mapIso8601ToDateString(booking.endAt) }.getOrElse { booking.endAt.take(10) }
+    val statusDateTime =
+        runCatching {
+            "${mapIso8601ToDateString(booking.createdAt)}, в ${mapIso8601ToTimeString(booking.createdAt)}"
+        }.getOrElse { booking.createdAt }
+    val relativeTime = runCatching { formatRelativeTime(Instant.parse(booking.createdAt)) }.getOrElse { "" }
+    val canConfirmOrDecline = booking.status.equals("Pending", ignoreCase = true) ||
+        booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
+
+    Column(
+        gap = 16.px,
+        modifier = {
+            width(100.percent)
+            property("box-sizing", "border-box")
+            padding(16.px)
+            borderRadius(12.px)
+            border(1.px, LineStyle.Solid, CSSColors.Gray300)
+        },
+    ) {
+        Row(
+            gap = 12.px,
+            alignItems = AlignItems.Center,
+            modifier = { width(100.percent) },
+        ) {
+            DealAvatar(name = renterName)
+            Column(gap = 4.px) {
+                Row(
+                    gap = 8.px,
+                    alignItems = AlignItems.Center,
+                    modifier = { width(100.percent) },
+                ) {
+                    Span({
+                        style {
+                            fontSize(16.px)
+                            fontWeight("600")
+                            color(CSSColors.Black)
+                        }
+                    }) {
+                        Text(renterName)
+                    }
+                    DealStatusTag(text = booking.status)
+                }
+                Span({
+                    style {
+                        fontSize(14.px)
+                        color(CSSColors.Gray600)
+                    }
+                }) {
+                    Text(carName)
+                }
+                Span({
+                    style {
+                        fontSize(13.px)
+                        color(CSSColors.Gray600)
+                    }
+                }) {
+                    Text("#$shortId")
+                }
+            }
+        }
+
+        Column(gap = 8.px) {
+            TextSmallBodyGray("ПЕРИОД АРЕНДЫ")
+            Span({
+                style {
+                    fontSize(14.px)
+                    color(CSSColors.Black)
+                }
+            }) {
+                Text("$durationHours ч: $periodStart - $periodEnd")
+            }
+        }
+
+        Column(gap = 8.px) {
+            TextSmallBodyGray("СТАТУС СДЕЛКИ")
+            Span({
+                style {
+                    fontSize(14.px)
+                    color(CSSColors.Black)
+                }
+            }) {
+                Text("${booking.status}: $statusDateTime")
+            }
+        }
+
+        Row(
+            justifyContent = JustifyContent.SpaceBetween,
+            alignItems = AlignItems.Center,
+            modifier = { width(100.percent) },
+        ) {
+            Span({
+                style {
+                    fontSize(13.px)
+                    color(CSSColors.Gray600)
+                }
+            }) {
+                Text(relativeTime)
+            }
+            if (canConfirmOrDecline && !isActionInProgress) {
+                Row(gap = 8.px) {
+                    Button({
+                        style {
+                            padding(8.px, 16.px)
+                            backgroundColor(CSSColors.Blue)
+                            color(CSSColors.White)
+                            border(0.px)
+                            borderRadius(6.px)
+                            cursor("pointer")
+                            fontSize(14.px)
+                            fontWeight("600")
+                        }
+                        onClick { onConfirm() }
+                    }) {
+                        Text("Подтвердить")
+                    }
+                    Button({
+                        style {
+                            padding(8.px, 16.px)
+                            backgroundColor(CSSColors.Gray600)
+                            color(CSSColors.White)
+                            border(0.px)
+                            borderRadius(6.px)
+                            cursor("pointer")
+                            fontSize(14.px)
+                            fontWeight("600")
+                        }
+                        onClick { onDecline() }
+                    }) {
+                        Text("Отклонить")
+                    }
+                }
+            }
+            if (canConfirmOrDecline && isActionInProgress) {
+                Span({
+                    style {
+                        fontSize(14.px)
+                        color(CSSColors.Gray600)
+                    }
+                }) {
+                    Text("Обработка...")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DealAvatar(name: String) {
+    val initial = name.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+    Div({
+        style {
+            width(48.px)
+            height(48.px)
+            borderRadius(50.percent)
+            display(DisplayStyle.Flex)
+            flexDirection(FlexDirection.Column)
+            alignItems(AlignItems.Center)
+            justifyContent(JustifyContent.Center)
+            backgroundColor(CSSColors.Gray300)
+            color(CSSColors.Gray600)
+            fontSize(18.px)
+            fontWeight("700")
+        }
+    }) {
+        Text(initial)
+    }
+}
+
+@Composable
+private fun DealStatusTag(text: String) {
+    val displayText = text.uppercase()
+    Span({
+        style {
+            padding(4.px, 8.px)
+            borderRadius(6.px)
+            backgroundColor(CSSColors.Gray300)
+            color(CSSColors.Gray600)
+            fontSize(12.px)
+            fontWeight("600")
+        }
+    }) {
+        Text(displayText)
+    }
+}


### PR DESCRIPTION
## Изменения

- Иконка Мои сделки заменена на currency-dollar (мобильное приложение + веб)
- Добавлен функционал Мои сделки: MyBookingsAsOwnerViewModel, MyDealsPage
- API confirm/decline: не парсим ответ, используем consumeResponse (сервер возвращает success/message)
- Исправлена иконка DealsIcon для Kotlin/JS (quadTo вместо cubicTo)