### PR TITLE
fix(seo): fast bot homepage — static prerender HTML, warm deploy, prerender cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -457,6 +457,7 @@ jobs:
         port: ${{ secrets.SERVER_PORT || 22 }}
         source: "scripts/warm-prerender-after-deploy.sh"
         target: "/tmp/"
+        strip_components: 1
 
     - name: Invalidate and warm Prerender cache
       continue-on-error: true
@@ -468,11 +469,22 @@ jobs:
         port: ${{ secrets.SERVER_PORT || 22 }}
         script: |
           set -e
-          chmod +x /tmp/warm-prerender-after-deploy.sh
+          SCRIPT=""
+          for p in /tmp/warm-prerender-after-deploy.sh /tmp/scripts/warm-prerender-after-deploy.sh; do
+            if [ -f "$p" ]; then SCRIPT="$p"; break; fi
+          done
+          if [ -z "$SCRIPT" ]; then
+            SCRIPT=$(find /tmp -maxdepth 4 -name 'warm-prerender-after-deploy.sh' -type f 2>/dev/null | head -1)
+          fi
+          if [ -z "$SCRIPT" ] || [ ! -f "$SCRIPT" ]; then
+            echo "❌ warm-prerender-after-deploy.sh not found under /tmp (check scp strip_components)"
+            exit 1
+          fi
+          chmod +x "$SCRIPT"
           export SITE_URL="https://drivebit.ru"
           export PRERENDER_COMPOSE_DIR="/opt/drivebit-prerender"
           export PRERENDER_SERVICE="prerender"
-          /tmp/warm-prerender-after-deploy.sh
+          "$SCRIPT"
 
     - name: Notify deployment success
       if: success()

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ open iosApp/iosApp.xcodeproj
 
 Боты получают статический HTML с каталогом машин. Для каждой машины генерируется отдельная страница в `car/{id}.html`. Пользователи получают SPA.
 
+### Googlebot и YandexBot
+
+В [`nginx-prerender.conf.example`](nginx-prerender.conf.example) в `map $http_user_agent $is_bot` заданы правила для поисковых ботов, в том числе **`~*yandex`**.
+
+**Главная `/`:** в актуальном примере для ботов отдаётся **статический** файл из деплоя (`prerender-bot-ru.html` для `drivebit.ru`, `prerender-bot.html` для `drivebit.my`) через `map $host$is_bot` и `try_files` — ответ **считан с диска**, без Chromium (приемлемо для краулеров). Остальные пути, где нет готового HTML, по-прежнему могут идти в динамический Prerender (`127.0.0.1:3000`).
+
+**In-memory кэш** Prerender (`prerender-memory-cache`) относится к сервису на :3000. Прогрев после деплоя ([`scripts/warm-prerender-after-deploy.sh`](scripts/warm-prerender-after-deploy.sh)) полезен для путей, которые реально проксируются в Prerender; для главной после включения статики в nginx критичен сам **деплой** файла `prerender-bot-ru.html`.
+
 ### Проверка prerender через curl
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@
                         <li><a href="#how-it-works">Как это работает</a></li>
                         <li><a href="#features">Преимущества</a></li>
                         <li><a href="#for-owners">Для владельцев</a></li>
-                        <li><a href="#contacts">Контакты</a></li>
+                        <li><a href="/contacts">Контакты</a></li>
                     </ul>
                 </nav>
                 <div class="auth-buttons">
@@ -806,9 +806,7 @@
                     <div class="footer-column">
                         <h3>Контакты</h3>
                         <ul>
-                            <li><a href="mailto:info@drivebit.ru">info@drivebit.ru</a></li>
-                            <li><a href="tel:+78001234567">8 (800) 123-45-67</a></li>
-                            <li><a href="#support">Техническая поддержка</a></li>
+                            <li><a href="/contacts">Реквизиты и связь</a></li>
                         </ul>
                     </div>
                 </div>

--- a/nginx-prerender-cache-http.conf.example
+++ b/nginx-prerender-cache-http.conf.example
@@ -1,0 +1,9 @@
+# Подключить один раз внутри блока http { } (например через include в /etc/nginx/nginx.conf):
+#
+#   include /etc/nginx/snippets/nginx-prerender-cache-http.conf;
+#
+# Перед первым запуском:
+#   sudo mkdir -p /var/cache/nginx/prerender
+#   sudo chown -R www-data:www-data /var/cache/nginx/prerender
+
+proxy_cache_path /var/cache/nginx/prerender levels=1:2 keys_zone=prerender_cache:20m max_size=512m inactive=24h use_temp_path=off;

--- a/nginx-prerender.conf.example
+++ b/nginx-prerender.conf.example
@@ -11,8 +11,9 @@
 # запрашивает ту же публичную страницу по $scheme://$host$request_uri.
 # Убедитесь, что с сервера/контейнера доступен этот URL (DNS, firewall).
 #
-# Статическая генерация (prerender-bot.html, car/*.html) в CI может оставаться для
-# кеша или отключаться — этот пример не использует rewrite на prerender-bot.html.
+# Главная для ботов: CI кладёт prerender-bot(-ru).html в root — отдаём файл с диска
+# (миллисекунды). Динамический Prerender на :3000 остаётся для путей без статики.
+# map $host$is_bot: суффикс is_bot — 0 человек, 1 бот.
 
 map $http_user_agent $is_bot {
     default 0;
@@ -23,6 +24,14 @@ map $http_user_agent $is_bot {
     ~*bot 1;
     ~*crawler 1;
     ~*spider 1;
+}
+
+map $host$is_bot $bot_home_file {
+    default /index.html;
+    drivebit.ru1 /prerender-bot-ru.html;
+    www.drivebit.ru1 /prerender-bot-ru.html;
+    drivebit.my1 /prerender-bot.html;
+    www.drivebit.my1 /prerender-bot.html;
 }
 
 server {
@@ -65,12 +74,9 @@ server {
         try_files /login-by-mail.html /index.html;
     }
 
-    # Главная: люди — SPA; боты — Prerender (динамический HTML)
+    # Главная: люди — index.html; боты — статический prerender-bot*.html из деплоя (быстро)
     location = / {
-        if ($is_bot) {
-            return 418;
-        }
-        try_files /index.html =404;
+        try_files $bot_home_file =404;
     }
 
     # Остальные пути: статика при наличии файла, иначе SPA; боты — Prerender

--- a/scripts/prerender-docker/.dockerignore
+++ b/scripts/prerender-docker/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.git
+*.md

--- a/scripts/prerender-docker/Dockerfile
+++ b/scripts/prerender-docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    chromium \
+    ca-certificates \
+    fonts-liberation \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+
+COPY server.js ./
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV CHROME_LOCATION=/usr/bin/chromium
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/scripts/prerender-docker/README.md
+++ b/scripts/prerender-docker/README.md
@@ -1,0 +1,66 @@
+# Self-hosted Prerender (Docker)
+
+Сервис на базе [prerender/prerender](https://github.com/prerender/prerender) (MIT): Headless Chromium отдаёт HTML после выполнения JS.
+
+## Запуск
+
+```bash
+cd scripts/prerender-docker
+docker compose up -d --build
+```
+
+Слушает только `127.0.0.1:3000` (см. `docker-compose.yml`). Nginx на хосте проксирует ботов на этот порт — см. `nginx-prerender.conf.example` в корне репозитория.
+
+**YandexBot:** в примере nginx в `map $is_bot` есть `~*yandex` — такие запросы идут в Prerender наравне с Googlebot. Кэш в памяти хранится по URL, не по UA; прогрев с Googlebot после деплоя покрывает и Яндекс. Подробнее — раздел «Prerender для роботов» в [корневом README](../../README.md).
+
+## Проверка
+
+```bash
+curl -sS -m 120 "http://127.0.0.1:3000/https://example.com" | head
+```
+
+Автоматический smoke-тест (эквивалент `curl http://127.0.0.1:3000/https://drivebit.ru/`) после `docker compose up`:
+
+```bash
+npm test
+# или явно
+PRERENDER_TARGET_URL=https://drivebit.ru/ npm test
+```
+
+Переменные: `PRERENDER_BASE`, `PRERENDER_TARGET_URL`, `PRERENDER_VERIFY_TIMEOUT_MS`.
+
+Память и CPU:
+
+```bash
+docker stats prerender-docker-prerender-1 --no-stream
+```
+
+(имя контейнера может отличаться; `docker ps` для точного имени.)
+
+## Переменные окружения
+
+| Переменная | Назначение |
+|------------|------------|
+| `PORT` | Порт внутри контейнера (по умолчанию `3000`) |
+| `CHROME_LOCATION` | Путь к Chromium (по умолчанию `/usr/bin/chromium`) |
+| `CHROME_EXTRA_FLAGS` | Доп. флаги через запятую |
+| `PAGE_LOAD_TIMEOUT` | Таймаут загрузки страницы (мс) |
+| `LOG_REQUESTS` | `true` для логов запросов |
+| `CACHE_TTL` | Секунды жизни записи в in-memory кэше Prerender (по умолчанию `60`) |
+| `CACHE_MAXSIZE` | Макс. число URL в памяти (по умолчанию `100`) |
+
+Первый запрос к URL по-прежнему рендерится в Chromium (секунды). Повторные запросы с тем же URL отдаются из **prerender-memory-cache** без повторного рендера. На стороне Nginx можно дополнительно включить **proxy_cache** для ответов `@prerender_bot` — см. [`nginx-prerender-cache-http.conf.example`](../../nginx-prerender-cache-http.conf.example) и комментарии в [`nginx-prerender.conf.example`](../../nginx-prerender.conf.example).
+
+## Инвалидация и прогрев после деплоя
+
+После выкладки нового фронта старый HTML может оставаться в памяти Prerender и в дисковом кэше Nginx. В CI ([`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)) после проверки `index.html` выполняется скрипт [`scripts/warm-prerender-after-deploy.sh`](../../scripts/warm-prerender-after-deploy.sh):
+
+1. `docker compose restart prerender` в `PRERENDER_COMPOSE_DIR` (по умолчанию `/opt/drivebit-prerender`) — сброс in-memory кэша.
+2. Очистка `/var/cache/nginx/prerender/*`, если каталог есть.
+3. Прогрев публичных URL с User-Agent бота: главная `SITE_URL`, затем `list-your-car.html` (если не задан `WARM_EXTRA_URLS`).
+
+Переменные окружения скрипта: `PRERENDER_COMPOSE_DIR`, `PRERENDER_SERVICE`, `SITE_URL`, `WARM_EXTRA_URLS`, `CURL_MAX_TIME`, `BOT_UA`. В workflow заданы `SITE_URL=https://drivebit.ru`, `PRERENDER_COMPOSE_DIR=/opt/drivebit-prerender`, `PRERENDER_SERVICE=prerender` (при необходимости измените в шаге **Invalidate and warm Prerender cache**). Шаг помечен `continue-on-error: true`, чтобы деплой не падал, если Prerender на сервере ещё не развёрнут.
+
+## Лимиты
+
+В `docker-compose.yml` заданы `deploy.resources.limits` (2G RAM, 1 CPU). При `docker compose` без Swarm Compose v2+ применяет лимиты; при необходимости задайте `mem_limit` вручную в вашей среде.

--- a/scripts/prerender-docker/docker-compose.yml
+++ b/scripts/prerender-docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  prerender:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      PORT: "3000"
+      NODE_ENV: production
+      CHROME_LOCATION: /usr/bin/chromium
+      PAGE_LOAD_TIMEOUT: "60000"
+      LOG_REQUESTS: "false"
+      CACHE_TTL: "600"
+      CACHE_MAXSIZE: "500"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2G

--- a/scripts/prerender-docker/package-lock.json
+++ b/scripts/prerender-docker/package-lock.json
@@ -1,0 +1,934 @@
+{
+  "name": "drivebit-prerender",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "drivebit-prerender",
+      "version": "1.0.0",
+      "dependencies": {
+        "prerender": "5.21.6",
+        "prerender-memory-cache": "^1.0.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-manager": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-2.11.1.tgz",
+      "integrity": "sha512-XhUuc9eYwkzpK89iNewFwtvcDYMUsvtwzHeyEOPJna/WsVsXcrzsA1ft2M0QqPNunEzLhNCYPo05tEfG+YuNow==",
+      "dependencies": {
+        "async": "1.5.2",
+        "lodash.clonedeep": "4.5.0",
+        "lru-cache": "4.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.30.1.tgz",
+      "integrity": "sha512-emKaqCjYAgrT35nm6PvTUKJ++2NX9qAmrcNRPRGyryG9Kc7wlkvO0bmvEdNMrr8Bih2e149WctJZFzUiM1UNwg==",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lru-cache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+      "integrity": "sha512-WKhDkjlLwzE8jAQdQlsxLUQTPXLCKX/4cJk6s5AlRtJkDBk0IKH5O51bVDH61K9N4bhbbyvLM6EiOuE8ovApPA==",
+      "dependencies": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/prerender": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/prerender/-/prerender-5.21.6.tgz",
+      "integrity": "sha512-75jGsgzWvljb2iKK/a7G+7KeAQORtqg19R9IdpnXgibNeSXFAN2JFq3G3CSpyaEus02d9OevXJzu9yUQZt+cqg==",
+      "dependencies": {
+        "body-parser": "^1.19.0",
+        "chrome-remote-interface": "^0.30.0",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "he": "^1.2.0",
+        "uuid": "^8.3.2",
+        "valid-url": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prerender-memory-cache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/prerender-memory-cache/-/prerender-memory-cache-1.0.2.tgz",
+      "integrity": "sha512-rnVPNQ8NFMVirXfHtgT8a9QTriu36Ctm8UYJZ0IFnvgygNmTSS/V9tcrjPNFcjklRz0drHlX9v/KsRWmL8BF2g==",
+      "dependencies": {
+        "cache-manager": "^2.6.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+    }
+  }
+}

--- a/scripts/prerender-docker/package.json
+++ b/scripts/prerender-docker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "drivebit-prerender",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Self-hosted Prerender.io server for Drivebit (Docker)",
+  "scripts": {
+    "test": "node verify-prerender-url.mjs",
+    "verify:drivebit-ru": "node verify-prerender-url.mjs"
+  },
+  "dependencies": {
+    "prerender": "5.21.6",
+    "prerender-memory-cache": "^1.0.2"
+  }
+}

--- a/scripts/prerender-docker/server.js
+++ b/scripts/prerender-docker/server.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const prerender = require("prerender");
+const memoryCache = require("prerender-memory-cache");
+
+const extraFlags = (process.env.CHROME_EXTRA_FLAGS ||
+  "--no-sandbox,--disable-dev-shm-usage,--disable-setuid-sandbox,--disable-gpu,--window-size=1920,1080")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const server = prerender({
+  port: process.env.PORT ? Number(process.env.PORT) : 3000,
+  chromeLocation: process.env.CHROME_LOCATION || "/usr/bin/chromium",
+  extraChromeFlags: extraFlags,
+});
+
+server.use(memoryCache);
+server.use(prerender.sendPrerenderHeader());
+server.use(prerender.browserForceRestart());
+server.use(prerender.addMetaTags());
+server.use(prerender.removeScriptTags());
+server.use(prerender.httpHeaders());
+
+server.start();

--- a/scripts/prerender-docker/verify-prerender-url.mjs
+++ b/scripts/prerender-docker/verify-prerender-url.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test: Prerender отдаёт HTML для целевого URL (по умолчанию drivebit.ru).
+ * Запуск: из каталога scripts/prerender-docker при поднятом `docker compose up`.
+ *
+ * Env:
+ *   PRERENDER_BASE — база сервиса (default http://127.0.0.1:3000)
+ *   PRERENDER_TARGET_URL — страница для рендера (default https://drivebit.ru/)
+ *   PRERENDER_VERIFY_TIMEOUT_MS — таймаут fetch (default 180000)
+ */
+
+const base = (process.env.PRERENDER_BASE || "http://127.0.0.1:3000").replace(/\/$/, "");
+let target = (process.env.PRERENDER_TARGET_URL || "https://drivebit.ru/").trim();
+const timeoutMs = Number(process.env.PRERENDER_VERIFY_TIMEOUT_MS || 180000);
+
+if (!/^https?:\/\//i.test(target)) {
+  console.error("verify-prerender-url: PRERENDER_TARGET_URL must be absolute http(s) URL, got:", target);
+  process.exit(1);
+}
+
+const requestUrl = `${base}/${target}`;
+
+async function main() {
+  console.log("GET", requestUrl);
+  const res = await fetch(requestUrl, {
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { Accept: "text/html,*/*" },
+  });
+
+  const text = await res.text();
+  const len = text.length;
+
+  if (!res.ok) {
+    console.error("verify-prerender-url: HTTP", res.status, len, "bytes");
+    process.exit(1);
+  }
+
+  if (len < 200) {
+    console.error("verify-prerender-url: body too short:", len);
+    process.exit(1);
+  }
+
+  const lower = text.toLowerCase();
+  if (!lower.includes("drivebit")) {
+    console.error("verify-prerender-url: expected 'DriveBit' in HTML body");
+    process.exit(1);
+  }
+
+  const hasPrerenderMeta =
+    text.includes("x-prerender-render-id") || text.includes("x-prerender-render-at");
+  if (!hasPrerenderMeta) {
+    console.warn("verify-prerender-url: no x-prerender meta (optional for static-ish HTML)");
+  }
+
+  console.log("verify-prerender-url: OK", res.status, len, "bytes");
+}
+
+main().catch((e) => {
+  console.error("verify-prerender-url:", e.message || e);
+  process.exit(1);
+});

--- a/scripts/warm-prerender-after-deploy.sh
+++ b/scripts/warm-prerender-after-deploy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Инвалидация in-memory кэша Prerender, дискового proxy_cache nginx и прогрев URL под UA бота.
+# Вызывается с сервера после деплоя (CI копирует и запускает по SSH).
+#
+# Переменные окружения:
+#   PRERENDER_COMPOSE_DIR — каталог с docker-compose.yml Prerender (по умолчанию /opt/drivebit-prerender)
+#   PRERENDER_SERVICE     — имя сервиса в compose (по умолчанию prerender)
+#   SITE_URL              — базовый URL сайта (по умолчанию https://drivebit.ru)
+#   WARM_EXTRA_URLS       — доп. URL через пробел (опционально)
+#   CURL_MAX_TIME         — таймаут curl в секундах (по умолчанию 120)
+#   BOT_UA                — User-Agent для прогрева (по умолчанию Googlebot)
+
+set -euo pipefail
+
+SUDO_CMD=""
+if [ "${EUID:-0}" -ne 0 ]; then
+  SUDO_CMD="sudo"
+fi
+
+PRERENDER_COMPOSE_DIR="${PRERENDER_COMPOSE_DIR:-/opt/drivebit-prerender}"
+PRERENDER_SERVICE="${PRERENDER_SERVICE:-prerender}"
+SITE_URL="${SITE_URL:-https://drivebit.ru}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-120}"
+BOT_UA="${BOT_UA:-Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)}"
+
+echo "🔥 warm-prerender-after-deploy: SITE_URL=$SITE_URL"
+
+if [ -d "$PRERENDER_COMPOSE_DIR" ] && [ -f "$PRERENDER_COMPOSE_DIR/docker-compose.yml" ] && command -v docker >/dev/null 2>&1; then
+  echo "🔄 Restarting Prerender (clears in-memory cache) in $PRERENDER_COMPOSE_DIR ..."
+  if (cd "$PRERENDER_COMPOSE_DIR" && docker compose restart "$PRERENDER_SERVICE"); then
+    echo "✅ docker compose restart $PRERENDER_SERVICE ok"
+  else
+    echo "⚠️  docker compose restart failed; trying docker restart on running prerender container ..."
+    id="$(docker ps -qf "name=${PRERENDER_SERVICE}" | head -1)"
+    if [ -n "$id" ]; then
+      docker restart "$id" && echo "✅ docker restart $id ok" || echo "⚠️  docker restart failed (non-fatal)"
+    else
+      echo "⚠️  No prerender container found (non-fatal)"
+    fi
+  fi
+else
+  echo "⚠️  Skip Prerender restart: missing $PRERENDER_COMPOSE_DIR/docker-compose.yml or docker (non-fatal)"
+fi
+
+if [ -d /var/cache/nginx/prerender ]; then
+  echo "🧹 Clearing nginx prerender proxy_cache: /var/cache/nginx/prerender"
+  $SUDO_CMD rm -rf /var/cache/nginx/prerender/*
+  echo "✅ Nginx prerender cache dir cleared"
+else
+  echo "ℹ️  /var/cache/nginx/prerender not present (nginx proxy_cache may be unused)"
+fi
+
+warm_one() {
+  local url="$1"
+  echo "🌡️  Warming: $url"
+  curl -sS -L -m "$CURL_MAX_TIME" \
+    -A "$BOT_UA" \
+    -o /dev/null \
+    -w "   http_code=%{http_code} time_total=%{time_total}s\n" \
+    "$url" || echo "   ⚠️  curl failed for $url (non-fatal)"
+}
+
+warm_one "${SITE_URL%/}/"
+
+for extra in ${WARM_EXTRA_URLS:-}; do
+  [ -n "$extra" ] || continue
+  warm_one "$extra"
+done
+
+# Доп. страницы по умолчанию (если не заданы через WARM_EXTRA_URLS)
+if [ -z "${WARM_EXTRA_URLS:-}" ]; then
+  warm_one "${SITE_URL%/}/list-your-car.html" || true
+fi
+
+echo "✅ warm-prerender-after-deploy finished"


### PR DESCRIPTION
## Summary
- Static bot homepage: nginx serves `prerender-bot-ru.html` / `prerender-bot.html` from disk for `/` when User-Agent is a bot (see `nginx-prerender.conf.example`).
- Deploy: fix SCP path for `warm-prerender-after-deploy.sh` (`strip_components`), SSH finds script and warms Prerender after deploy.
- Prerender Docker: in-memory cache (`prerender-memory-cache`), env in compose.
- README and `index.html` contact/footer tweaks.

## Verification
- `./gradlew check` — BUILD SUCCESSFUL (local, this session).
