### PR TITLE
feat(web): страницы результата оплаты и переход во Входящие

### DIFF
--- a/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
@@ -37,6 +37,8 @@ import my.drivebit.screens.MyDealsPage
 import my.drivebit.screens.ContactsPage
 import my.drivebit.screens.OfferPage
 import my.drivebit.screens.OtpVerificationPage
+import my.drivebit.screens.PaymentFailurePage
+import my.drivebit.screens.PaymentSuccessPage
 import my.drivebit.screens.PrivacyPage
 import my.drivebit.screens.DocumentsPage
 import my.drivebit.screens.ProductionYearInputPage
@@ -155,6 +157,12 @@ actual fun App() {
                 }
                 currentPath.startsWith("/privacy") -> {
                     PrivacyPage()
+                }
+                currentPath.startsWith("/payment-success") -> {
+                    PaymentSuccessPage()
+                }
+                currentPath.startsWith("/payment-failure") -> {
+                    PaymentFailurePage()
                 }
                 currentPath.startsWith("/car-edit") -> {
                     CarEditPage()

--- a/composeApp/src/jsMain/kotlin/my/drivebit/navigation/MetaTags.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/navigation/MetaTags.kt
@@ -69,6 +69,20 @@ object MetaTags {
                     path = "/chat",
                     noindex = true,
                 ),
+            "/payment-success" to
+                PageMeta(
+                    title = "Оплата успешна - DriveBit",
+                    description = "Платёж в DriveBit успешно завершён.",
+                    path = "/payment-success",
+                    noindex = true,
+                ),
+            "/payment-failure" to
+                PageMeta(
+                    title = "Оплата не прошла - DriveBit",
+                    description = "Платёж в DriveBit не был завершён.",
+                    path = "/payment-failure",
+                    noindex = true,
+                ),
         )
 
     fun updateForPath(path: String) {

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/PaymentFailurePage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/PaymentFailurePage.kt
@@ -1,0 +1,107 @@
+package my.drivebit.screens
+
+import androidx.compose.runtime.Composable
+import kotlinx.browser.window
+import my.drivebit.components.ActionButton
+import my.drivebit.components.AppWithHeader
+import my.drivebit.components.Column
+import my.drivebit.design.CSSColors
+import my.drivebit.design.CSSTypography
+import my.drivebit.design.applyTypography
+import my.drivebit.utils.getUrlParameter
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.P
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun PaymentFailurePage() {
+    val details = getUrlParameter("details").trim()
+
+    AppWithHeader {
+        Div({
+            style {
+                padding(24.px)
+                maxWidth(560.px)
+                property("margin", "0 auto")
+            }
+        }) {
+            Column(
+                gap = 20.px,
+                modifier = {
+                    alignItems(AlignItems.Center)
+                    property("text-align", "center")
+                },
+            ) {
+                Div({
+                    style {
+                        width(72.px)
+                        height(72.px)
+                        borderRadius(50.percent)
+                        backgroundColor(CSSColors.Red)
+                        color(CSSColors.White)
+                        display(DisplayStyle.Flex)
+                        alignItems(AlignItems.Center)
+                        justifyContent(JustifyContent.Center)
+                        fontSize(CSSTypography.FontSize.xxxl)
+                        fontWeight(CSSTypography.FontWeight.bold)
+                    }
+                }) {
+                    Text("×")
+                }
+
+                P({
+                    style {
+                        applyTypography(CSSTypography.Styles.body)
+                        fontSize(CSSTypography.FontSize.xxl)
+                        fontWeight(CSSTypography.FontWeight.semibold)
+                        property("margin", "0")
+                    }
+                }) {
+                    Text("Оплата не прошла")
+                }
+
+                P({
+                    style {
+                        applyTypography(CSSTypography.Styles.body)
+                        color(CSSColors.Gray600)
+                        lineHeight("1.6")
+                        property("margin", "0")
+                    }
+                }) {
+                    Text(
+                        "Платёж не был завершён или был отклонён. Проверьте данные карты и баланс, либо выберите другой способ оплаты.",
+                    )
+                }
+
+                if (details.isNotEmpty()) {
+                    P({
+                        style {
+                            applyTypography(CSSTypography.Styles.caption)
+                            color(CSSColors.Gray600)
+                            lineHeight("1.5")
+                            property("margin", "0")
+                            property("word-break", "break-word")
+                        }
+                    }) {
+                        Text(details)
+                    }
+                }
+
+                Div({
+                    style {
+                        width(100.percent)
+                        maxWidth(400.px)
+                        marginTop(8.px)
+                    }
+                }) {
+                    ActionButton(
+                        enabledColor = CSSColors.Blue,
+                        text = "Входящие",
+                        onClick = { window.location.href = "/chats" },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/PaymentSuccessPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/PaymentSuccessPage.kt
@@ -1,0 +1,90 @@
+package my.drivebit.screens
+
+import androidx.compose.runtime.Composable
+import kotlinx.browser.window
+import my.drivebit.components.ActionButton
+import my.drivebit.components.AppWithHeader
+import my.drivebit.components.Column
+import my.drivebit.design.CSSColors
+import my.drivebit.design.CSSTypography
+import my.drivebit.design.applyTypography
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.P
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun PaymentSuccessPage() {
+    AppWithHeader {
+        Div({
+            style {
+                padding(24.px)
+                maxWidth(560.px)
+                property("margin", "0 auto")
+            }
+        }) {
+            Column(
+                gap = 20.px,
+                modifier = {
+                    alignItems(AlignItems.Center)
+                    property("text-align", "center")
+                },
+            ) {
+                Div({
+                    style {
+                        width(72.px)
+                        height(72.px)
+                        borderRadius(50.percent)
+                        backgroundColor(CSSColors.Green)
+                        color(CSSColors.White)
+                        display(DisplayStyle.Flex)
+                        alignItems(AlignItems.Center)
+                        justifyContent(JustifyContent.Center)
+                        fontSize(CSSTypography.FontSize.xxxl)
+                        fontWeight(CSSTypography.FontWeight.bold)
+                    }
+                }) {
+                    Text("✓")
+                }
+
+                P({
+                    style {
+                        applyTypography(CSSTypography.Styles.body)
+                        fontSize(CSSTypography.FontSize.xxl)
+                        fontWeight(CSSTypography.FontWeight.semibold)
+                        property("margin", "0")
+                    }
+                }) {
+                    Text("Оплата прошла успешно")
+                }
+
+                P({
+                    style {
+                        applyTypography(CSSTypography.Styles.body)
+                        color(CSSColors.Gray600)
+                        lineHeight("1.6")
+                        property("margin", "0")
+                    }
+                }) {
+                    Text(
+                        "Спасибо! Платёж принят. Если это бронирование, статус обновится в разделе «Мои бронирования».",
+                    )
+                }
+
+                Div({
+                    style {
+                        width(100.percent)
+                        maxWidth(400.px)
+                        marginTop(8.px)
+                    }
+                }) {
+                    ActionButton(
+                        enabledColor = CSSColors.Blue,
+                        text = "Входящие",
+                        onClick = { window.location.href = "/chats" },
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Добавлены маршруты /payment-success и /payment-failure с экранами в стиле сайта, мета-тегами noindex и кнопкой «Входящие» (/chats). Страница ошибки поддерживает query-параметр details для текста от платёжки.

Made-with: Cursor