### PR TITLE
feat(chat): оплата из чата и разбор systemMessageType как строки

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ChatDetailViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ChatDetailViewModel.kt
@@ -3,17 +3,32 @@ package my.drivebit.viewmodels
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import my.drivebit.network.services.Chat
 import my.drivebit.network.services.ChatDetailDto
 import my.drivebit.network.services.MessageDto
+import my.drivebit.network.services.PayBookingResult
+import my.drivebit.network.services.Payment
 import my.drivebit.network.services.SendMessageRequest
 import my.drivebit.repositories.ParticipantAvatarCache
 import my.drivebit.utils.safeLaunchWithErrorHandler
+
+sealed interface ChatPayEffect {
+    data class OpenCheckout(
+        val url: String,
+    ) : ChatPayEffect
+
+    data class ShowInfo(
+        val text: String,
+    ) : ChatPayEffect
+}
 
 interface ChatDetailViewModel {
     val chatDetail: StateFlow<ChatDetailDto?>
@@ -22,6 +37,10 @@ interface ChatDetailViewModel {
     val error: StateFlow<String?>
     val isSending: StateFlow<Boolean>
 
+    val isPaying: StateFlow<Boolean>
+
+    val payEffects: SharedFlow<ChatPayEffect>
+
     fun loadChat()
 
     fun loadMessages()
@@ -29,10 +48,17 @@ interface ChatDetailViewModel {
     fun loadMoreMessages(before: String)
 
     fun sendMessage(text: String)
+
+    fun payBooking(
+        bookingId: String,
+        returnUrl: String,
+        failUrl: String,
+    )
 }
 
 class ChatDetailViewModelImpl(
     private val chat: Chat,
+    private val payment: Payment,
     private val chatId: String,
     private val participantAvatarCache: ParticipantAvatarCache,
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
@@ -51,6 +77,12 @@ class ChatDetailViewModelImpl(
 
     private val _isSending = MutableStateFlow(false)
     override val isSending: StateFlow<Boolean> = _isSending.asStateFlow()
+
+    private val _isPaying = MutableStateFlow(false)
+    override val isPaying: StateFlow<Boolean> = _isPaying.asStateFlow()
+
+    private val _payEffects = MutableSharedFlow<ChatPayEffect>(extraBufferCapacity = 1)
+    override val payEffects: SharedFlow<ChatPayEffect> = _payEffects.asSharedFlow()
 
     override fun loadChat() {
         coroutineScope.safeLaunchWithErrorHandler(
@@ -122,6 +154,38 @@ class ChatDetailViewModelImpl(
         ) {
             val message = chat.sendMessage(SendMessageRequest(chatId = chatId, text = text))
             _messages.update { it + message }
+        }
+    }
+
+    override fun payBooking(
+        bookingId: String,
+        returnUrl: String,
+        failUrl: String,
+    ) {
+        if (bookingId.isBlank() || _isPaying.value) return
+        coroutineScope.launch {
+            _isPaying.value = true
+            try {
+                when (val result = payment.registerBookingPayment(bookingId, returnUrl, failUrl)) {
+                    is PayBookingResult.Redirect ->
+                        _payEffects.emit(ChatPayEffect.OpenCheckout(result.url))
+                    is PayBookingResult.AlreadyPaid -> {
+                        val text =
+                            result.message?.takeIf { it.isNotBlank() }
+                                ?: "Оплата уже выполнена"
+                        _payEffects.emit(ChatPayEffect.ShowInfo(text))
+                        runCatching {
+                            val refreshed = chat.getMessages(chatId, limit = 50)
+                            _messages.value =
+                                (refreshed.messages ?: emptyList()).sortedBy { it.createdAt }
+                        }
+                    }
+                    is PayBookingResult.Failed ->
+                        _payEffects.emit(ChatPayEffect.ShowInfo(result.message))
+                }
+            } finally {
+                _isPaying.value = false
+            }
         }
     }
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/RentViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/RentViewModel.kt
@@ -4,8 +4,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -13,7 +16,19 @@ import kotlinx.datetime.Instant
 import my.drivebit.network.services.Booking
 import my.drivebit.network.services.CheckBookingAvailabilityRequest
 import my.drivebit.network.services.CreateBookingRequest
+import my.drivebit.network.services.PayBookingResult
+import my.drivebit.network.services.Payment
 import my.drivebit.shared.storage.Storage
+
+sealed interface RentPayEffect {
+    data class OpenCheckout(
+        val url: String,
+    ) : RentPayEffect
+
+    data class ShowInfo(
+        val text: String,
+    ) : RentPayEffect
+}
 
 sealed interface RentState {
     data class Book(
@@ -26,6 +41,7 @@ sealed interface RentState {
         val depositAmount: String = "",
         val isCreating: Boolean = false,
         val createError: String? = null,
+        val pendingPaymentBookingId: String? = null,
     ) : RentState
 
     data object NavigateToMyBookings : RentState
@@ -39,6 +55,8 @@ sealed interface RentState {
 
 interface RentViewModel {
     val state: StateFlow<RentState>
+    val isPaying: StateFlow<Boolean>
+    val payEffects: SharedFlow<RentPayEffect>
 
     fun setStartDate(date: String?)
 
@@ -52,10 +70,18 @@ interface RentViewModel {
     fun consumeNavigationEvent()
 
     fun onBookClick()
+
+    fun payCreatedBooking(
+        returnUrl: String,
+        failUrl: String,
+    )
+
+    fun requestNavigateToMyBookings()
 }
 
 class RentViewModelImpl(
     private val booking: Booking,
+    private val payment: Payment,
     private val storage: Storage,
     private val carId: String,
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
@@ -66,6 +92,12 @@ class RentViewModelImpl(
 
     private val _state = MutableStateFlow<RentState>(RentState.Book())
     override val state: StateFlow<RentState> = _state.asStateFlow()
+
+    private val _isPaying = MutableStateFlow(false)
+    override val isPaying: StateFlow<Boolean> = _isPaying.asStateFlow()
+
+    private val _payEffects = MutableSharedFlow<RentPayEffect>(extraBufferCapacity = 1)
+    override val payEffects: SharedFlow<RentPayEffect> = _payEffects.asSharedFlow()
 
     override fun consumeNavigationEvent() {
         _state.value = RentState.Book()
@@ -87,7 +119,12 @@ class RentViewModelImpl(
                         }
                         else -> currentEnd
                     }
-                it.copy(startDate = date, endDate = endDate, showStartDateError = false)
+                it.copy(
+                    startDate = date,
+                    endDate = endDate,
+                    showStartDateError = false,
+                    pendingPaymentBookingId = null,
+                )
             } else {
                 it
             }
@@ -98,7 +135,7 @@ class RentViewModelImpl(
     override fun setEndDate(date: String?) {
         _state.update {
             if (it is RentState.Book) {
-                it.copy(endDate = date, showEndDateError = false)
+                it.copy(endDate = date, showEndDateError = false, pendingPaymentBookingId = null)
             } else {
                 it
             }
@@ -128,6 +165,7 @@ class RentViewModelImpl(
                     endDate = endDateValid,
                     showStartDateError = false,
                     showEndDateError = false,
+                    pendingPaymentBookingId = null,
                 )
             } else {
                 it
@@ -142,6 +180,7 @@ class RentViewModelImpl(
 
     override fun onBookClick() {
         val current = _state.value as? RentState.Book ?: return
+        if (current.pendingPaymentBookingId != null) return
         if (!storage.isLogined()) {
             _state.value =
                 RentState.NavigateToLogin(
@@ -188,8 +227,18 @@ class RentViewModelImpl(
                             endAt = end,
                         ),
                     )
-                }.onSuccess {
-                    _state.value = RentState.NavigateToMyBookings
+                }.onSuccess { dto ->
+                    _state.update { s ->
+                        if (s is RentState.Book) {
+                            s.copy(
+                                isCreating = false,
+                                createError = null,
+                                pendingPaymentBookingId = dto.id,
+                            )
+                        } else {
+                            s
+                        }
+                    }
                 }.onFailure { e ->
                     _state.update { s ->
                         if (s is RentState.Book) {
@@ -340,4 +389,36 @@ class RentViewModelImpl(
             val end = Instant.parse(endAt)
             (end - start).inWholeDays.toInt().coerceAtLeast(1)
         }.getOrElse { 1 }
+
+    override fun payCreatedBooking(
+        returnUrl: String,
+        failUrl: String,
+    ) {
+        val current = _state.value as? RentState.Book ?: return
+        val bookingId = current.pendingPaymentBookingId ?: return
+        if (bookingId.isBlank() || _isPaying.value) return
+        viewModelScope.launch {
+            _isPaying.value = true
+            try {
+                when (val result = payment.registerBookingPayment(bookingId, returnUrl, failUrl)) {
+                    is PayBookingResult.Redirect ->
+                        _payEffects.emit(RentPayEffect.OpenCheckout(result.url))
+                    is PayBookingResult.AlreadyPaid -> {
+                        val text =
+                            result.message?.takeIf { it.isNotBlank() }
+                                ?: "Оплата уже выполнена"
+                        _payEffects.emit(RentPayEffect.ShowInfo(text))
+                    }
+                    is PayBookingResult.Failed ->
+                        _payEffects.emit(RentPayEffect.ShowInfo(result.message))
+                }
+            } finally {
+                _isPaying.value = false
+            }
+        }
+    }
+
+    override fun requestNavigateToMyBookings() {
+        _state.value = RentState.NavigateToMyBookings
+    }
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
@@ -209,6 +209,7 @@ val commonViewModelsModule: Module =
         factory<ChatDetailViewModel> { (chatId: String) ->
             ChatDetailViewModelImpl(
                 chat = get(),
+                payment = get(),
                 chatId = chatId,
                 participantAvatarCache = get(),
             )

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
@@ -419,6 +419,7 @@ val commonViewModelsModule: Module =
         factory<RentViewModel> { (carId: String) ->
             RentViewModelImpl(
                 booking = get(),
+                payment = get(),
                 storage = get(),
                 carId = carId,
             )

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.test.runTest
 import my.drivebit.network.services.Booking
 import my.drivebit.network.services.CheckBookingAvailabilityRequest
 import my.drivebit.network.services.CheckBookingAvailabilityResponse
+import my.drivebit.network.services.PayBookingResult
+import my.drivebit.network.services.Payment
 import my.drivebit.shared.storage.Storage
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -83,6 +85,14 @@ private class FakeBooking(
         )
 }
 
+private class FakePayment : Payment {
+    override suspend fun registerBookingPayment(
+        bookingId: String,
+        returnUrl: String,
+        failUrl: String,
+    ): PayBookingResult = PayBookingResult.Failed("unused in test")
+}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class RentViewModelTest {
     @Test
@@ -94,6 +104,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -118,6 +129,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -142,6 +154,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -164,6 +177,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -176,6 +190,12 @@ class RentViewModelTest {
             viewModel.onBookClick()
             advanceUntilIdle()
 
+            val created = viewModel.state.value as RentState.Book
+            assertEquals("booking-1", created.pendingPaymentBookingId)
+            assertFalse(created.isCreating)
+            assertFalse(created.showStartDateError)
+            assertFalse(created.showEndDateError)
+            viewModel.requestNavigateToMyBookings()
             assertTrue(viewModel.state.value is RentState.NavigateToMyBookings)
             viewModel.consumeNavigationEvent()
             val state = viewModel.state.value as RentState.Book
@@ -193,6 +213,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -217,6 +238,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -241,6 +263,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-123",
                     coroutineScope = testScope,
@@ -274,6 +297,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -307,6 +331,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,
@@ -339,6 +364,7 @@ class RentViewModelTest {
             val viewModel =
                 RentViewModelImpl(
                     booking = booking,
+                    payment = FakePayment(),
                     storage = storage,
                     carId = "car-1",
                     coroutineScope = testScope,

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/chat/ChatScreen.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/chat/ChatScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -24,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -31,12 +33,17 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import kotlinx.coroutines.delay
 import my.drivebit.network.services.MessageDto
+import my.drivebit.network.services.payBookingIdForAction
 import my.drivebit.ui.components.ApplicationTopBar
 import my.drivebit.ui.components.Loader
 import my.drivebit.utils.mapIso8601ToTimeString
 import my.drivebit.viewmodels.ChatDetailViewModel
+import my.drivebit.viewmodels.ChatPayEffect
 import org.koin.compose.currentKoinScope
 import org.koin.core.parameter.parametersOf
+
+private const val MOBILE_PAYMENT_SUCCESS_URL = "https://drivebit.ru/payment-success"
+private const val MOBILE_PAYMENT_FAIL_URL = "https://drivebit.ru/payment-failure"
 
 data class ChatScreen(
     val chatId: String,
@@ -53,7 +60,29 @@ data class ChatScreen(
         val messages by viewModel.messages.collectAsState()
         val isLoading by viewModel.isLoading.collectAsState()
         val error by viewModel.error.collectAsState()
+        val isPaying by viewModel.isPaying.collectAsState()
         var messageText by remember { mutableStateOf("") }
+        var payInfo by remember { mutableStateOf<String?>(null) }
+        val uriHandler = LocalUriHandler.current
+
+        LaunchedEffect(chatId) {
+            viewModel.payEffects.collect { effect ->
+                when (effect) {
+                    is ChatPayEffect.OpenCheckout -> uriHandler.openUri(effect.url)
+                    is ChatPayEffect.ShowInfo -> {
+                        payInfo = effect.text
+                    }
+                }
+            }
+        }
+
+        LaunchedEffect(payInfo) {
+            val msg = payInfo
+            if (msg != null) {
+                delay(6_000)
+                payInfo = null
+            }
+        }
 
         LaunchedEffect(chatId) {
             viewModel.loadChat()
@@ -82,6 +111,14 @@ data class ChatScreen(
                     Column(
                         modifier = Modifier.padding(innerPadding).fillMaxSize(),
                     ) {
+                        payInfo?.let { info ->
+                            Text(
+                                text = info,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            )
+                        }
                         LazyColumn(
                             modifier = Modifier.weight(1f).fillMaxWidth(),
                             reverseLayout = true,
@@ -94,6 +131,14 @@ data class ChatScreen(
                                 MessageBubble(
                                     message = message,
                                     participantId = chatDetail?.participant?.id,
+                                    isPaying = isPaying,
+                                    onPayBooking = { bookingId ->
+                                        viewModel.payBooking(
+                                            bookingId = bookingId,
+                                            returnUrl = MOBILE_PAYMENT_SUCCESS_URL,
+                                            failUrl = MOBILE_PAYMENT_FAIL_URL,
+                                        )
+                                    },
                                 )
                             }
                         }
@@ -141,6 +186,8 @@ data class ChatScreen(
 private fun MessageBubble(
     message: MessageDto,
     participantId: String? = null,
+    isPaying: Boolean = false,
+    onPayBooking: (String) -> Unit = {},
 ) {
     val senderId = message.sender?.id
     val isOwnMessage = participantId != null && senderId != null && senderId != participantId
@@ -169,11 +216,26 @@ private fun MessageBubble(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
-            Text(
-                text = message.text ?: "Системное сообщение",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            val bookingIdForPay = message.payBookingIdForAction()
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = message.text ?: "Системное сообщение",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (bookingIdForPay != null) {
+                    Button(
+                        onClick = { onPayBooking(bookingIdForPay) },
+                        enabled = !isPaying,
+                        modifier = Modifier.padding(top = 8.dp),
+                    ) {
+                        Text(if (isPaying) "Загрузка…" else "Оплатить")
+                    }
+                }
+            }
         }
     }
 }

--- a/Network/src/commonMain/kotlin/my/drivebit/network/di/NetworkModule.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/di/NetworkModule.kt
@@ -22,6 +22,8 @@ import my.drivebit.network.services.Dictionary
 import my.drivebit.network.services.DictionaryImpl
 import my.drivebit.network.services.Documents
 import my.drivebit.network.services.DocumentsImpl
+import my.drivebit.network.services.Payment
+import my.drivebit.network.services.PaymentImpl
 import my.drivebit.network.services.Photo
 import my.drivebit.network.services.PhotoImpl
 import my.drivebit.network.services.Review
@@ -148,6 +150,9 @@ val networkModule =
         }
         single<Chat> {
             ChatImpl(get(named("authorized")))
+        }
+        single<Payment> {
+            PaymentImpl(get(named("authorized")))
         }
         single<Review> {
             ReviewImpl(

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
@@ -7,9 +7,53 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNames
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import my.drivebit.network.DEFAULT_BASE_URL
 import my.drivebit.network.parseResponse
+
+const val MESSAGE_ACTION_PAY_BOOKING = 1
+
+const val SYSTEM_MESSAGE_PAYMENT_REQUEST = "PaymentRequest"
+
+object SystemMessageTypeAsStringSerializer : KSerializer<String?> {
+    private val backing = String.serializer().nullable
+
+    override val descriptor: SerialDescriptor = backing.descriptor
+
+    override fun deserialize(decoder: Decoder): String? {
+        if (decoder is JsonDecoder) {
+            val element = decoder.decodeJsonElement()
+            if (element is JsonNull) return null
+            val prim = element as? JsonPrimitive ?: return null
+            return prim.contentOrNull?.takeIf { it.isNotBlank() }
+        }
+        return backing.deserialize(decoder)
+    }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: String?,
+    ) {
+        backing.serialize(encoder, value)
+    }
+}
+
+@Serializable
+data class MessageActionBlockDto(
+    val actionType: Int,
+    val actionParameters: Map<String, String>? = null,
+)
 
 interface Chat {
     suspend fun hasUnread(): HasUnreadResponse
@@ -100,6 +144,12 @@ data class MessageDto(
     val isRead: Boolean = false,
     val createdAt: String,
     val isSystemMessage: Boolean = false,
+    @JsonNames("messageActionBlock", "MessageActionBlock")
+    val messageActionBlock: MessageActionBlockDto? = null,
+    @JsonNames("bookingId", "BookingId") val bookingId: String? = null,
+    @Serializable(with = SystemMessageTypeAsStringSerializer::class)
+    @JsonNames("systemMessageType", "SystemMessageType")
+    val systemMessageType: String? = null,
 )
 
 @Serializable
@@ -107,6 +157,19 @@ data class SendMessageRequest(
     val chatId: String,
     val text: String? = null,
 )
+
+fun MessageDto.payBookingIdForAction(): String? {
+    if (!isSystemMessage) return null
+    val booking =
+        messageActionBlock?.actionParameters?.get("bookingId")?.takeIf { it.isNotBlank() }
+            ?: bookingId?.takeIf { it.isNotBlank() }
+            ?: return null
+    if (messageActionBlock?.actionType == MESSAGE_ACTION_PAY_BOOKING) return booking
+    if (systemMessageType?.equals(SYSTEM_MESSAGE_PAYMENT_REQUEST, ignoreCase = true) == true) {
+        return booking
+    }
+    return null
+}
 
 class ChatImpl(
     private val httpClient: HttpClient,

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
@@ -10,7 +10,6 @@ import io.ktor.http.contentType
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -19,31 +18,92 @@ import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import my.drivebit.network.DEFAULT_BASE_URL
 import my.drivebit.network.parseResponse
 
-const val MESSAGE_ACTION_PAY_BOOKING = 1
+@Serializable
+enum class ActionTypeEnum {
+    None,
+    PayBooking,
+    LeaveReviewForRenter,
+    LeaveReviewForCar,
+    ConfirmBooking,
+}
 
-const val SYSTEM_MESSAGE_PAYMENT_REQUEST = "PaymentRequest"
-
-object SystemMessageTypeAsStringSerializer : KSerializer<String?> {
-    private val backing = String.serializer().nullable
+object ActionTypeEnumSerializer : KSerializer<ActionTypeEnum> {
+    private val backing = ActionTypeEnum.serializer()
 
     override val descriptor: SerialDescriptor = backing.descriptor
 
-    override fun deserialize(decoder: Decoder): String? {
+    override fun deserialize(decoder: Decoder): ActionTypeEnum {
         if (decoder is JsonDecoder) {
             val element = decoder.decodeJsonElement()
-            if (element is JsonNull) return null
-            val prim = element as? JsonPrimitive ?: return null
-            return prim.contentOrNull?.takeIf { it.isNotBlank() }
+            if (element is JsonNull) return ActionTypeEnum.None
+            val prim = element as? JsonPrimitive ?: return ActionTypeEnum.None
+            val raw = prim.contentOrNull?.trim().orEmpty()
+            if (raw.isNotEmpty()) {
+                ActionTypeEnum.entries.find { it.name == raw }?.let { return it }
+            }
+            prim.intOrNull?.let { ord ->
+                return ActionTypeEnum.entries.getOrNull(ord) ?: ActionTypeEnum.None
+            }
+            return ActionTypeEnum.None
         }
         return backing.deserialize(decoder)
     }
 
     override fun serialize(
         encoder: Encoder,
-        value: String?,
+        value: ActionTypeEnum,
+    ) {
+        backing.serialize(encoder, value)
+    }
+}
+
+@Serializable
+enum class SystemMessageType {
+    BookingRequest,
+    BookingConfirmed,
+    BookingDeclined,
+    BookingActive,
+    BookingCompleted,
+    BookingCancelledByRenter,
+    BookingCancelledByOwner,
+    BookingExpired,
+    PaymentRequest,
+    PaymentReceived,
+    BookingPaid,
+    BookingPaymentExpired,
+    BookingRefunded,
+    BookingStatusChanged,
+    General,
+}
+
+object SystemMessageTypeNullableSerializer : KSerializer<SystemMessageType?> {
+    private val backing = SystemMessageType.serializer().nullable
+
+    override val descriptor: SerialDescriptor = backing.descriptor
+
+    override fun deserialize(decoder: Decoder): SystemMessageType? {
+        if (decoder is JsonDecoder) {
+            val element = decoder.decodeJsonElement()
+            if (element is JsonNull) return null
+            val prim = element as? JsonPrimitive ?: return null
+            val raw = prim.contentOrNull?.trim() ?: return null
+            if (raw.isEmpty()) return null
+            SystemMessageType.entries.find { it.name == raw }?.let { return it }
+            prim.intOrNull?.let { ord ->
+                return SystemMessageType.entries.getOrNull(ord)
+            }
+            return null
+        }
+        return backing.deserialize(decoder)
+    }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: SystemMessageType?,
     ) {
         backing.serialize(encoder, value)
     }
@@ -51,7 +111,8 @@ object SystemMessageTypeAsStringSerializer : KSerializer<String?> {
 
 @Serializable
 data class MessageActionBlockDto(
-    val actionType: Int,
+    @Serializable(with = ActionTypeEnumSerializer::class)
+    val actionType: ActionTypeEnum = ActionTypeEnum.None,
     val actionParameters: Map<String, String>? = null,
 )
 
@@ -147,9 +208,9 @@ data class MessageDto(
     @JsonNames("messageActionBlock", "MessageActionBlock")
     val messageActionBlock: MessageActionBlockDto? = null,
     @JsonNames("bookingId", "BookingId") val bookingId: String? = null,
-    @Serializable(with = SystemMessageTypeAsStringSerializer::class)
+    @Serializable(with = SystemMessageTypeNullableSerializer::class)
     @JsonNames("systemMessageType", "SystemMessageType")
-    val systemMessageType: String? = null,
+    val systemMessageType: SystemMessageType? = null,
 )
 
 @Serializable
@@ -164,8 +225,13 @@ fun MessageDto.payBookingIdForAction(): String? {
         messageActionBlock?.actionParameters?.get("bookingId")?.takeIf { it.isNotBlank() }
             ?: bookingId?.takeIf { it.isNotBlank() }
             ?: return null
-    if (messageActionBlock?.actionType == MESSAGE_ACTION_PAY_BOOKING) return booking
-    if (systemMessageType?.equals(SYSTEM_MESSAGE_PAYMENT_REQUEST, ignoreCase = true) == true) {
+    when (messageActionBlock?.actionType) {
+        ActionTypeEnum.PayBooking,
+        ActionTypeEnum.ConfirmBooking,
+        -> return booking
+        else -> {}
+    }
+    if (systemMessageType == SystemMessageType.PaymentRequest) {
         return booking
     }
     return null

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Payment.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Payment.kt
@@ -1,0 +1,117 @@
+package my.drivebit.network.services
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import my.drivebit.network.DEFAULT_BASE_URL
+import my.drivebit.network.ValidationErrorResponse
+import my.drivebit.network.collectErrorMessages
+import my.drivebit.network.defaultJson
+
+interface Payment {
+    suspend fun registerBookingPayment(
+        bookingId: String,
+        returnUrl: String,
+        failUrl: String,
+    ): PayBookingResult
+}
+
+sealed class PayBookingResult {
+    data class Redirect(
+        val url: String,
+    ) : PayBookingResult()
+
+    data class AlreadyPaid(
+        val message: String? = null,
+    ) : PayBookingResult()
+
+    data class Failed(
+        val message: String,
+    ) : PayBookingResult()
+}
+
+@Serializable
+private data class RegisterPaymentResponse(
+    val paymentUrl: String? = null,
+)
+
+@Serializable
+private data class PaymentAlreadyReportedBody(
+    val message: String? = null,
+)
+
+class PaymentImpl(
+    private val httpClient: HttpClient,
+) : Payment {
+    override suspend fun registerBookingPayment(
+        bookingId: String,
+        returnUrl: String,
+        failUrl: String,
+    ): PayBookingResult {
+        val response =
+            httpClient.post("${DEFAULT_BASE_URL}Payment/booking/$bookingId/pay") {
+                parameter("returnUrl", returnUrl)
+                parameter("failUrl", failUrl)
+            }
+        val bodyString = response.bodyAsText()
+        return when {
+            response.status == HttpStatusCode.OK -> {
+                val dto =
+                    runCatching {
+                        defaultJson.decodeFromString(RegisterPaymentResponse.serializer(), bodyString)
+                    }.getOrElse {
+                        return PayBookingResult.Failed("Не удалось разобрать ответ оплаты")
+                    }
+                val url = dto.paymentUrl?.takeIf { it.isNotBlank() }
+                if (url != null) {
+                    PayBookingResult.Redirect(url)
+                } else {
+                    PayBookingResult.Failed("Пустая ссылка на оплату")
+                }
+            }
+            response.status.value == 208 -> {
+                val msg =
+                    runCatching {
+                        defaultJson.decodeFromString(PaymentAlreadyReportedBody.serializer(), bodyString).message
+                    }.getOrNull()
+                PayBookingResult.AlreadyPaid(message = msg)
+            }
+            !response.status.isSuccess() -> {
+                PayBookingResult.Failed(extractErrorMessage(bodyString, defaultJson))
+            }
+            else -> {
+                PayBookingResult.Failed("Неожиданный ответ сервера: ${response.status}")
+            }
+        }
+    }
+}
+
+private fun extractErrorMessage(
+    bodyString: String,
+    json: Json,
+): String {
+    val trimmedBody = bodyString.trim()
+    return runCatching {
+        if (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) {
+            val errorResponse = json.decodeFromString(ValidationErrorResponse.serializer(), trimmedBody)
+            val errorMessages = errorResponse.errors?.collectErrorMessages().orEmpty()
+            when {
+                !errorResponse.message.isNullOrBlank() -> errorResponse.message
+                errorMessages.isNotEmpty() -> errorMessages.joinToString(". ")
+                errorResponse.detail != null -> errorResponse.detail
+                errorResponse.error != null -> errorResponse.error
+                errorResponse.title != null -> errorResponse.title
+                else -> trimmedBody.trim('"').trim()
+            }
+        } else {
+            trimmedBody.trim('"').trim()
+        }
+    }.getOrElse {
+        trimmedBody.trim('"').trim()
+    }
+}

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/PaymentRegisterBookingTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/PaymentRegisterBookingTest.kt
@@ -1,0 +1,86 @@
+package my.drivebit.network.services
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PaymentRegisterBookingTest {
+    @Test
+    fun `registerBookingPayment returns Redirect when 200 with paymentUrl`() =
+        runTest {
+            val bookingId = "550e8400-e29b-41d4-a716-446655440000"
+            val mockEngine =
+                MockEngine { request ->
+                    assertTrue(request.url.encodedPath.contains(bookingId))
+                    assertTrue(request.url.parameters["returnUrl"] == "https://example.com/ok")
+                    assertTrue(request.url.parameters["failUrl"] == "https://example.com/fail")
+                    respond(
+                        content = """{"paymentUrl":"https://pay.example/checkout"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val client = HttpClient(mockEngine)
+            val payment = PaymentImpl(client)
+            val result =
+                payment.registerBookingPayment(
+                    bookingId = bookingId,
+                    returnUrl = "https://example.com/ok",
+                    failUrl = "https://example.com/fail",
+                )
+            val redirect = assertIs<PayBookingResult.Redirect>(result)
+            assertEquals("https://pay.example/checkout", redirect.url)
+        }
+
+    @Test
+    fun `registerBookingPayment returns AlreadyPaid when 208`() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = """{"message":"Уже оплачено"}""",
+                        status = HttpStatusCode(208, "Already Reported"),
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val payment = PaymentImpl(HttpClient(mockEngine))
+            val result =
+                payment.registerBookingPayment(
+                    bookingId = "550e8400-e29b-41d4-a716-446655440000",
+                    returnUrl = "https://a",
+                    failUrl = "https://b",
+                )
+            val already = assertIs<PayBookingResult.AlreadyPaid>(result)
+            assertEquals("Уже оплачено", already.message)
+        }
+
+    @Test
+    fun `registerBookingPayment returns Failed on 400 with message`() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = """{"message":"Нельзя оплатить"}""",
+                        status = HttpStatusCode.BadRequest,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val payment = PaymentImpl(HttpClient(mockEngine))
+            val result =
+                payment.registerBookingPayment(
+                    bookingId = "550e8400-e29b-41d4-a716-446655440000",
+                    returnUrl = "https://a",
+                    failUrl = "https://b",
+                )
+            val failed = assertIs<PayBookingResult.Failed>(result)
+            assertEquals("Нельзя оплатить", failed.message)
+        }
+}

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/CarBook.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import kotlinx.browser.window
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -26,6 +27,7 @@ import my.drivebit.utils.addDays
 import my.drivebit.utils.encodeUrlParameter
 import my.drivebit.viewmodels.ButtonState
 import my.drivebit.viewmodels.DateTimeFieldViewModel
+import my.drivebit.viewmodels.RentPayEffect
 import my.drivebit.viewmodels.RentState
 import my.drivebit.viewmodels.RentViewModel
 import my.drivebit.viewmodels.createButtonViewModel
@@ -45,8 +47,23 @@ fun CarBook(
     initialEndAt: String? = null,
 ) {
     val state by viewModel.state.collectAsState()
+    val isPaying by viewModel.isPaying.collectAsState()
     val navigationController = LocalNavigationController.current
     val buttonViewModel = createButtonViewModel()
+    val payButtonViewModel = createButtonViewModel()
+
+    LaunchedEffect(Unit) {
+        viewModel.payEffects.collect { effect ->
+            when (effect) {
+                is RentPayEffect.OpenCheckout -> {
+                    window.location.href = effect.url
+                }
+                is RentPayEffect.ShowInfo -> {
+                    window.alert(effect.text)
+                }
+            }
+        }
+    }
 
     LaunchedEffect(state) {
         when (state) {
@@ -126,10 +143,18 @@ fun CarBook(
     val startDateTimeViewModel = remember { DateTimeFieldViewModel() }
     val endDateTimeViewModel = remember { DateTimeFieldViewModel() }
 
-    LaunchedEffect(bookState.isCreating) {
+    LaunchedEffect(bookState.isCreating, bookState.pendingPaymentBookingId) {
         buttonViewModel.setState(
-            if (bookState.isCreating) ButtonState.Loading else ButtonState.Enabled,
+            when {
+                bookState.isCreating -> ButtonState.Loading
+                bookState.pendingPaymentBookingId != null -> ButtonState.Disabled
+                else -> ButtonState.Enabled
+            },
         )
+    }
+
+    LaunchedEffect(isPaying) {
+        payButtonViewModel.setState(if (isPaying) ButtonState.Loading else ButtonState.Enabled)
     }
     val startDateTimeState by startDateTimeViewModel.state.collectAsState()
     val endDateTimeState by endDateTimeViewModel.state.collectAsState()
@@ -272,6 +297,53 @@ fun CarBook(
                     viewModel.onBookClick()
                 },
             )
+            bookState.pendingPaymentBookingId?.let {
+                Span({
+                    style {
+                        display(DisplayStyle.Block)
+                        applyTypography(CSSTypography.Styles.body)
+                        fontSize(CSSTypography.FontSize.sm)
+                        color(CSSColors.Gray600)
+                        marginTop((-4).px)
+                    }
+                }) {
+                    Text("Бронирование создано. Оплатите, чтобы подтвердить.")
+                }
+                ActionButton(
+                    viewModel = payButtonViewModel,
+                    enabledColor = CSSColors.Blue,
+                    text = "Оплатить",
+                    onClick = {
+                        val origin = window.location.origin
+                        viewModel.payCreatedBooking(
+                            returnUrl = "$origin/payment-success",
+                            failUrl = "$origin/payment-failure",
+                        )
+                    },
+                )
+                Div({
+                    style {
+                        width(100.percent)
+                        textAlign("center")
+                        marginTop(4.px)
+                    }
+                    onClick {
+                        viewModel.requestNavigateToMyBookings()
+                    }
+                }) {
+                    Span({
+                        style {
+                            applyTypography(CSSTypography.Styles.body)
+                            fontSize(CSSTypography.FontSize.sm)
+                            color(CSSColors.Blue)
+                            property("cursor", "pointer")
+                            property("text-decoration", "underline")
+                        }
+                    }) {
+                        Text("Мои бронирования")
+                    }
+                }
+            }
             bookState.createError?.let { error ->
                 Span({
                     style {

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/ChatDetailPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/ChatDetailPage.kt
@@ -17,13 +17,18 @@ import my.drivebit.components.MessageTextWithDealsLink
 import my.drivebit.components.ParticipantAvatar
 import my.drivebit.components.Row
 import my.drivebit.components.TextError
+import my.drivebit.components.ActionButton
 import my.drivebit.components.ToolbarBackArrow
 import my.drivebit.design.CSSColors
 import my.drivebit.network.services.MessageDto
+import my.drivebit.network.services.payBookingIdForAction
 import my.drivebit.utils.getUrlParameter
 import my.drivebit.utils.mapIso8601ToTimeString
+import my.drivebit.viewmodels.ButtonState
 import my.drivebit.viewmodels.ChatDetailViewModel
+import my.drivebit.viewmodels.ChatPayEffect
 import my.drivebit.viewmodels.UnreadMessagesViewModel
+import my.drivebit.viewmodels.createButtonViewModel
 import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.attributes.disabled
 import org.jetbrains.compose.web.attributes.placeholder
@@ -66,6 +71,20 @@ fun ChatDetailPage() {
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
     val isSending by viewModel.isSending.collectAsState()
+    val isPaying by viewModel.isPaying.collectAsState()
+
+    LaunchedEffect(chatId) {
+        viewModel.payEffects.collect { effect ->
+            when (effect) {
+                is ChatPayEffect.OpenCheckout -> {
+                    window.location.href = effect.url
+                }
+                is ChatPayEffect.ShowInfo -> {
+                    window.alert(effect.text)
+                }
+            }
+        }
+    }
 
     LaunchedEffect(chatId) {
         viewModel.loadChat()
@@ -131,6 +150,15 @@ fun ChatDetailPage() {
                                         participantId = chatDetail?.participant?.id,
                                         participantName = chatDetail?.participant?.name,
                                         participantAvatarUrl = chatDetail?.participant?.avatar,
+                                        isPaying = isPaying,
+                                        onPayBooking = { bookingId ->
+                                            val origin = window.location.origin
+                                            viewModel.payBooking(
+                                                bookingId = bookingId,
+                                                returnUrl = "$origin/payment-success",
+                                                failUrl = "$origin/payment-failure",
+                                            )
+                                        },
                                     )
                                 }
                             }
@@ -209,6 +237,8 @@ private fun MessageBubble(
     participantId: String? = null,
     participantName: String? = null,
     participantAvatarUrl: String? = null,
+    isPaying: Boolean = false,
+    onPayBooking: (String) -> Unit = {},
 ) {
     val isSystemMessage = message.isSystemMessage
     val senderId = message.sender?.id
@@ -223,6 +253,11 @@ private fun MessageBubble(
     val timeStr = runCatching { mapIso8601ToTimeString(message.createdAt) }.getOrElse { "" }
 
     if (isSystemMessage) {
+        val bookingIdForPay = message.payBookingIdForAction()
+        val payButtonVm = createButtonViewModel()
+        LaunchedEffect(isPaying) {
+            payButtonVm.setState(if (isPaying) ButtonState.Loading else ButtonState.Enabled)
+        }
         Div({
             style {
                 padding(8.px)
@@ -231,7 +266,30 @@ private fun MessageBubble(
                 fontSize(13.px)
             }
         }) {
-            MessageTextWithDealsLink(text = text.ifBlank { "Системное сообщение" })
+            Column(
+                gap = 8.px,
+                modifier = {
+                    width(100.percent)
+                    alignItems(AlignItems.Center)
+                },
+            ) {
+                MessageTextWithDealsLink(text = text.ifBlank { "Системное сообщение" })
+                if (bookingIdForPay != null) {
+                    Div({
+                        style {
+                            width(100.percent)
+                            maxWidth(280.px)
+                        }
+                    }) {
+                        ActionButton(
+                            text = "Оплатить",
+                            enabledColor = CSSColors.Blue,
+                            viewModel = payButtonVm,
+                            onClick = { onPayBooking(bookingIdForPay) },
+                        )
+                    }
+                }
+            }
         }
         return
     }


### PR DESCRIPTION
- Сервис Payment: POST Payment/booking/{id}/pay с returnUrl/failUrl; PayBookingResult (редирект, уже оплачено, ошибка).

- MessageDto: messageActionBlock, bookingId, systemMessageType (String + кастомный JSON-сериализатор).

- payBookingIdForAction: PayBooking в блоке или PaymentRequest по типу системного сообщения.

- ChatDetailViewModel: payBooking, payEffects, isPaying; веб и мобильный UI «Оплатить».

- Тесты PaymentRegisterBookingTest.

Made-with: Cursor