### PR TITLE
feat(car): insurance in API, detail page and editor

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditMviViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditMviViewModel.kt
@@ -14,6 +14,7 @@ import my.drivebit.network.services.CarAddress
 import my.drivebit.network.services.CarBrand
 import my.drivebit.network.services.CarCreateRequest
 import my.drivebit.network.services.CarDetailResponse
+import my.drivebit.network.services.CarInsuranceType
 import my.drivebit.network.services.CarModel
 import my.drivebit.repositories.EnumItem
 import my.drivebit.repositories.MyCarRepository
@@ -127,6 +128,10 @@ sealed interface CarEditIntent {
 
     data class UpdateAvailableMileagePerDayKm(
         val value: String,
+    ) : CarEditIntent
+
+    data class SelectInsurance(
+        val apiValue: String?,
     ) : CarEditIntent
 
     data class UpdateDescription(
@@ -433,6 +438,20 @@ class CarEditMviViewModelImpl(
             is CarEditIntent.UpdateAvailableMileagePerDayKm -> {
                 updateFormData { it.copy(availableMileagePerDayKm = intent.value) }
             }
+            is CarEditIntent.SelectInsurance -> {
+                val v = intent.apiValue?.trim()?.takeIf { it.isNotEmpty() }
+                updateFormData {
+                    it.copy(
+                        insurance = v,
+                        insuranceTranslate =
+                            if (v == null || v in CarInsuranceType.knownApiValues) {
+                                null
+                            } else {
+                                it.insuranceTranslate
+                            },
+                    )
+                }
+            }
             is CarEditIntent.UpdateDescription -> {
                 updateFormData { it.copy(description = intent.value) }
             }
@@ -575,6 +594,7 @@ class CarEditMviViewModelImpl(
                         dailyRate21Days = dailyRate21DaysValue,
                         deposit = depositValue,
                         availableMileagePerDayKm = availableMileagePerDayKmValue,
+                        insurance = formData.insurance?.trim()?.takeIf { it.isNotEmpty() },
                         ParkingAssistances = emptyList(),
                         MultimediaSystemOptions = emptyList(),
                     )
@@ -786,6 +806,8 @@ class CarEditMviViewModelImpl(
                 car.dailyRate21Days?.takeIf { it > 0 }?.let { NumberFormatter.formatInt(it.toInt()) } ?: "",
             deposit = car.deposit?.takeIf { it > 0 }?.let { NumberFormatter.formatInt(it.toInt()) } ?: "",
             availableMileagePerDayKm = car.availableMileagePerDayKm?.let { NumberFormatter.formatInt(it) } ?: "",
+            insurance = car.insurance?.trim()?.takeIf { it.isNotEmpty() },
+            insuranceTranslate = car.insuranceTranslate?.trim()?.takeIf { it.isNotEmpty() },
             photos = car.photos,
         )
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import my.drivebit.network.services.Car
 import my.drivebit.network.services.CarCreateRequest
 import my.drivebit.network.services.CarDetailResponse
+import my.drivebit.network.services.CarInsuranceType
 
 sealed interface CarEditState {
     data object Loading : CarEditState
@@ -60,6 +61,8 @@ data class CarEditFormData(
     val dailyRate21Days: String = "",
     val deposit: String = "",
     val availableMileagePerDayKm: String = "",
+    val insurance: String? = null,
+    val insuranceTranslate: String? = null,
     val photos: List<my.drivebit.network.services.CarPhotoItem> = emptyList(),
 )
 
@@ -239,6 +242,8 @@ class CarEditViewModelImpl(
                     ?.takeIf { it > 0 }
                     ?.let { NumberFormatter.formatInt(it) } ?: "",
             availableMileagePerDayKm = car.availableMileagePerDayKm?.let { NumberFormatter.formatInt(it) } ?: "",
+            insurance = car.insurance?.trim()?.takeIf { it.isNotEmpty() },
+            insuranceTranslate = car.insuranceTranslate?.trim()?.takeIf { it.isNotEmpty() },
             photos = car.photos,
         )
     }
@@ -393,6 +398,7 @@ class CarEditViewModelImpl(
                         deposit = formData.deposit.takeIf { it.isNotBlank() }?.toIntOrNull(),
                         availableMileagePerDayKm =
                             formData.availableMileagePerDayKm.takeIf { it.isNotBlank() }?.toIntOrNull(),
+                        insurance = formData.insurance?.trim()?.takeIf { it.isNotEmpty() },
                         ParkingAssistances = emptyList(),
                         MultimediaSystemOptions = emptyList(),
                     )

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -73,8 +73,7 @@ data class CreateBookingRequest(
     val comment: String? = null,
 )
 
-fun BookingDTO.statusAllowsRenterPayment(): Boolean =
-    status.equals("Confirmed", ignoreCase = true)
+fun BookingDTO.statusAllowsRenterPayment(): Boolean = status.equals("Confirmed", ignoreCase = true)
 
 fun BookingDTO.isTerminalRenterBooking(): Boolean =
     status.equals("Completed", ignoreCase = true) ||

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
@@ -143,6 +143,8 @@ data class CarDetailResponse(
     val dailyRate21Days: Double? = null,
     val seatsCount: Int? = null,
     val availableMileagePerDayKm: Int? = null,
+    val insurance: String? = null,
+    val insuranceTranslate: String? = null,
     val deposit: Double? = null,
     val owner: String = "",
     val carBookings: List<CarBookingItem> = emptyList(),
@@ -184,6 +186,8 @@ data class CarDetailResponse(
     fun resolvedDailyRate(): Int = dailyRate?.toInt() ?: 0
 
     fun resolvedDeposit(): Int = deposit?.toInt() ?: 0
+
+    fun resolvedInsuranceDisplay(): String? = insuranceTranslate?.trim()?.takeIf { it.isNotEmpty() }
 }
 
 @Serializable
@@ -246,6 +250,24 @@ data class CarAddress(
     val geoLon: Double? = null,
 )
 
+object CarInsuranceType {
+    const val OSAGO_INCLUDED = "OSAGO_Included"
+    const val OSAGO_UNLIMITED = "OSAGO_Unlimited"
+    const val KASKO_INCLUDED = "KASKO_Included"
+    const val KASKO_UNLIMITED = "KASKO_Unlimited"
+
+    val knownApiValues: Set<String> =
+        setOf(OSAGO_INCLUDED, OSAGO_UNLIMITED, KASKO_INCLUDED, KASKO_UNLIMITED)
+
+    val optionsForUi: List<Pair<String, String>> =
+        listOf(
+            OSAGO_INCLUDED to "ОСАГО включено",
+            OSAGO_UNLIMITED to "ОСАГО без лимита",
+            KASKO_INCLUDED to "КАСКО включено",
+            KASKO_UNLIMITED to "КАСКО без лимита",
+        )
+}
+
 @Serializable
 data class CarPhotoItem(
     val id: Int,
@@ -278,6 +300,7 @@ data class CarCreateRequest(
     val dailyRate21Days: Int? = null,
     val deposit: Int? = null,
     val availableMileagePerDayKm: Int? = null,
+    val insurance: String? = null,
     @SerialName("parkingAssistances") val ParkingAssistances: List<Int> = emptyList(),
     @SerialName("multimediaSystemOptions") val MultimediaSystemOptions: List<Int> = emptyList(),
 )

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
@@ -15,6 +15,7 @@ import my.drivebit.network.parseResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class CarDetailResponseTest {
     @Test
@@ -126,6 +127,8 @@ class CarDetailResponseTest {
                     "seatsCount": 5,
                     "licensePlate": "K128CT",
                     "ValidAddressString": "Test Address",
+                    "insurance": "OSAGO_Included",
+                    "insuranceTranslate": "ОСАГО включено",
                     "photos": []
                 }
                 """.trimIndent()
@@ -172,5 +175,27 @@ class CarDetailResponseTest {
             assertEquals(5, result.seatsCount)
             assertEquals("K128CT", result.licensePlate)
             assertEquals("Test Address", result.ValidAddressString)
+            assertEquals("OSAGO_Included", result.insurance)
+            assertEquals("ОСАГО включено", result.insuranceTranslate)
+            assertEquals("ОСАГО включено", result.resolvedInsuranceDisplay())
         }
+
+    @Test
+    fun `resolvedInsuranceDisplay is null when insuranceTranslate is absent`() {
+        val car =
+            CarDetailResponse(
+                id = "x",
+                general =
+                    CarGeneral(
+                        brandName = "A",
+                        modelName = "B",
+                        vin = "",
+                        seats = 5,
+                        address = CarAddress(geoLat = 0.0, geoLon = 0.0),
+                    ),
+                insurance = "OSAGO_Included",
+                insuranceTranslate = null,
+            )
+        assertNull(car.resolvedInsuranceDisplay())
+    }
 }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/CarInsuranceSelectField.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/CarInsuranceSelectField.kt
@@ -1,0 +1,87 @@
+package my.drivebit.components
+
+import androidx.compose.runtime.Composable
+import my.drivebit.design.CSSColors
+import my.drivebit.design.CSSTypography
+import my.drivebit.design.applyTypography
+import my.drivebit.network.services.CarInsuranceType
+import org.jetbrains.compose.web.attributes.selected
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.Option
+import org.jetbrains.compose.web.dom.Select
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+import org.w3c.dom.HTMLSelectElement
+
+@Composable
+fun CarInsuranceSelectField(
+    insurance: String?,
+    insuranceTranslate: String?,
+    onSelect: (String?) -> Unit,
+) {
+    val current = insurance.orEmpty()
+    Column(gap = 12.px) {
+        Span({
+            style {
+                applyTypography(CSSTypography.Styles.body)
+                fontSize(CSSTypography.FontSize.sm)
+                fontWeight(CSSTypography.FontWeight.medium)
+                color(CSSColors.Black)
+            }
+        }) {
+            Text("Страховка")
+        }
+        Select(
+            attrs = {
+                onChange { event ->
+                    val v = (event.target as HTMLSelectElement).value
+                    onSelect(v.takeIf { it.isNotBlank() })
+                }
+                style {
+                    display(DisplayStyle.Block)
+                    width(100.percent)
+                    padding(12.px, 14.px)
+                    fontSize(CSSTypography.FontSize.base)
+                    border(1.px, LineStyle.Solid, CSSColors.Gray600)
+                    borderRadius(8.px)
+                }
+            },
+        ) {
+            Option(
+                value = "",
+                attrs = {
+                    if (current.isEmpty()) selected()
+                },
+            ) {
+                Text("Не указано")
+            }
+            CarInsuranceType.optionsForUi.forEach { (api, label) ->
+                val displayLabel =
+                    if (current == api) {
+                        insuranceTranslate?.takeIf { it.isNotBlank() } ?: label
+                    } else {
+                        label
+                    }
+                Option(
+                    value = api,
+                    attrs = {
+                        if (current == api) selected()
+                    },
+                ) {
+                    Text(displayLabel)
+                }
+            }
+            val raw = insurance?.trim().orEmpty()
+            if (raw.isNotEmpty() && raw !in CarInsuranceType.knownApiValues) {
+                Option(
+                    value = raw,
+                    attrs = {
+                        if (current == raw) selected()
+                    },
+                ) {
+                    Text(insuranceTranslate?.takeIf { it.isNotBlank() } ?: raw)
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/jsMain/kotlin/my/drivebit/components/DailyRateLabel.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/components/DailyRateLabel.kt
@@ -92,6 +92,43 @@ fun CarRatesSection(car: CarDetailResponse) {
 }
 
 @Composable
+fun CarInsuranceSection(car: CarDetailResponse) {
+    val text = car.resolvedInsuranceDisplay() ?: return
+
+    Div({
+        style {
+            marginTop(16.px)
+            padding(16.px, 20.px)
+            property("background-color", CSSColors.WhiteString)
+            property("border-radius", "12px")
+            property("border", "1px solid ${CSSColors.Gray300String}")
+            property("box-sizing", "border-box")
+        }
+    }) {
+        Div({
+            style {
+                fontSize(CSSTypography.FontSize.sm)
+                fontWeight(CSSTypography.FontWeight.medium)
+                color(CSSColors.Black)
+                marginBottom(8.px)
+            }
+        }) {
+            Text("Страховка")
+        }
+        Div({
+            style {
+                fontSize(CSSTypography.FontSize.lg)
+                fontWeight(CSSTypography.FontWeight.normal)
+                color(CSSColors.Black)
+                property("line-height", "1.4")
+            }
+        }) {
+            Text(text)
+        }
+    }
+}
+
+@Composable
 fun CarDepositSection(car: CarDetailResponse) {
     val deposit = car.deposit?.takeIf { it > 0 }?.toInt() ?: return
 

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarDetailPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarDetailPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import my.drivebit.components.AppWithHeader
 import my.drivebit.components.CarBook
 import my.drivebit.components.CarDepositSection
+import my.drivebit.components.CarInsuranceSection
 import my.drivebit.components.CarDescription
 import my.drivebit.components.CarLocationMap
 import my.drivebit.components.CarOwnerSection
@@ -231,6 +232,8 @@ private fun CarDetailInfoColumn(
         CarSpecsRow(car)
 
         CarDescription(description = car.general.description)
+
+        CarInsuranceSection(car)
 
         owner?.let { ownerInfo ->
             CarOwnerSection(

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlinx.browser.window
 import my.drivebit.components.ActionButton
+import my.drivebit.components.CarInsuranceSelectField
 import my.drivebit.components.CenteredFormContainer
 import my.drivebit.components.Column
 import my.drivebit.components.FormSection
@@ -454,6 +455,12 @@ fun CarEditPage() {
                                     }
                                 },
                                 numeric = true,
+                            )
+
+                            CarInsuranceSelectField(
+                                insurance = formData.insurance,
+                                insuranceTranslate = formData.insuranceTranslate,
+                                onSelect = { viewModel.handleIntent(CarEditIntent.SelectInsurance(it)) },
                             )
 
                             TextInputField(


### PR DESCRIPTION
## Summary

Adds car **insurance** end-to-end for the web client: `CarDetailResponse` / `CarCreateRequest` fields, `CarInsuranceType` helpers, deserialization test, car-edit form state and save, car detail card (`CarInsuranceSection`), and insurance select on `car-edit` (`CarInsuranceSelectField`). Display uses **`insuranceTranslate`** when present.

## Scope

Eight source files only (no scripts, static assets, vendored libs, or generated HTML).