### PR TITLE
feat(web): show full city list on my-city selection

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CityViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CityViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.launch
 import my.drivebit.network.services.City
 import my.drivebit.repositories.CityRepository
 import my.drivebit.repositories.ResultCities
@@ -32,12 +33,20 @@ class CityViewModel(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    private val _browseAllCitiesMode = MutableStateFlow(false)
+    private val _fullCityCatalog = MutableStateFlow<List<City>>(emptyList())
+
     init {
         _query
             .debounce(debounceTimeMs)
             .distinctUntilChanged()
             .flatMapLatest { query ->
                 flow {
+                    if (_browseAllCitiesMode.value && _fullCityCatalog.value.isNotEmpty()) {
+                        applyBrowseAllFilter(query.trim())
+                        emit(Unit)
+                        return@flow
+                    }
                     if (query.isNotBlank()) {
                         searchCities(query)
                     } else {
@@ -49,8 +58,49 @@ class CityViewModel(
             }.launchIn(coroutineScope)
     }
 
+    fun enableBrowseAllCitiesMode() {
+        coroutineScope.launch {
+            _browseAllCitiesMode.value = true
+            _error.value = null
+            when (val result = cityRepository.getAllCities()) {
+                is ResultCities.Success -> {
+                    _fullCityCatalog.value = result.cities
+                    applyBrowseAllFilter(_query.value.trim())
+                }
+                is ResultCities.Error -> {
+                    _fullCityCatalog.value = emptyList()
+                    _cities.value = emptyList()
+                    _error.value = result.message
+                }
+            }
+        }
+    }
+
+    fun setSearchOnlyMode() {
+        _browseAllCitiesMode.value = false
+        _fullCityCatalog.value = emptyList()
+        _query.value = ""
+        _cities.value = emptyList()
+        _error.value = null
+    }
+
     fun updateQuery(newQuery: String) {
         _query.value = newQuery
+    }
+
+    private fun applyBrowseAllFilter(trimmedQuery: String) {
+        _error.value = null
+        val catalog = _fullCityCatalog.value
+        val filtered =
+            if (trimmedQuery.isEmpty()) {
+                catalog
+            } else {
+                catalog.filter { city ->
+                    city.name.contains(trimmedQuery, ignoreCase = true) ||
+                        (city.regionName?.contains(trimmedQuery, ignoreCase = true) == true)
+                }
+            }
+        _cities.value = filtered.sortedBy { it.name }
     }
 
     private suspend fun searchCities(query: String) {
@@ -72,7 +122,11 @@ class CityViewModel(
 
     fun clearQuery() {
         _query.value = ""
-        _cities.value = emptyList()
+        if (_browseAllCitiesMode.value && _fullCityCatalog.value.isNotEmpty()) {
+            _cities.value = _fullCityCatalog.value.sortedBy { it.name }
+        } else {
+            _cities.value = emptyList()
+        }
         _error.value = null
     }
 }

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CityViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CityViewModelTest.kt
@@ -20,6 +20,7 @@ private class FakeCityRepository : CityRepository {
     var errorMessage: String = "Error"
     var lastQuery: String? = null
     var callCount = 0
+    var getAllCallCount = 0
 
     override suspend fun searchCities(query: String): ResultCities {
         lastQuery = query
@@ -31,6 +32,19 @@ private class FakeCityRepository : CityRepository {
             listOf(
                 City(id = 1, name = "Москва"),
                 City(id = 2, name = "Московская область"),
+            ),
+        )
+    }
+
+    override suspend fun getAllCities(): ResultCities {
+        getAllCallCount++
+        if (shouldReturnError) {
+            return ResultCities.Error(errorMessage)
+        }
+        return ResultCities.Success(
+            listOf(
+                City(id = 10, name = "Казань", regionName = "Татарстан"),
+                City(id = 11, name = "Калининград", regionName = "Калининградская область"),
             ),
         )
     }
@@ -235,5 +249,60 @@ class CityViewModelTest {
             assertEquals("", viewModel.query.value)
             assertTrue(viewModel.cities.value.isEmpty())
             assertNull(viewModel.error.value)
+        }
+
+    @Test
+    fun `browse all mode loads catalog and filters locally by query`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher()
+            val testScope = CoroutineScope(SupervisorJob() + testDispatcher)
+            val fakeRepo = FakeCityRepository()
+            val viewModel =
+                CityViewModel(
+                    cityRepository = fakeRepo,
+                    coroutineScope = testScope,
+                    debounceTimeMs = 100,
+                )
+
+            viewModel.enableBrowseAllCitiesMode()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1, fakeRepo.getAllCallCount)
+            assertEquals(2, viewModel.cities.value.size)
+            assertEquals("Казань", viewModel.cities.value[0].name)
+            assertEquals("Калининград", viewModel.cities.value[1].name)
+
+            viewModel.updateQuery("Калинин")
+            testDispatcher.scheduler.advanceTimeBy(100)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(1, viewModel.cities.value.size)
+            assertEquals("Калининград", viewModel.cities.value[0].name)
+            assertEquals(0, fakeRepo.callCount)
+        }
+
+    @Test
+    fun `clearQuery in browse all mode restores full catalog`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher()
+            val testScope = CoroutineScope(SupervisorJob() + testDispatcher)
+            val fakeRepo = FakeCityRepository()
+            val viewModel =
+                CityViewModel(
+                    cityRepository = fakeRepo,
+                    coroutineScope = testScope,
+                    debounceTimeMs = 100,
+                )
+
+            viewModel.enableBrowseAllCitiesMode()
+            testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.updateQuery("Казань")
+            testDispatcher.scheduler.advanceTimeBy(100)
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, viewModel.cities.value.size)
+
+            viewModel.clearQuery()
+
+            assertEquals(2, viewModel.cities.value.size)
         }
 }

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CityRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CityRepository.kt
@@ -5,6 +5,8 @@ import my.drivebit.network.services.Dictionary
 
 interface CityRepository {
     suspend fun searchCities(query: String): ResultCities
+
+    suspend fun getAllCities(): ResultCities
 }
 
 sealed interface ResultCities {
@@ -23,6 +25,16 @@ class CityRepositoryImpl(
     override suspend fun searchCities(query: String): ResultCities =
         runCatching {
             dictionary.searchCities(query)
+        }.fold(
+            onSuccess = { cities -> ResultCities.Success(cities) },
+            onFailure = { exception ->
+                ResultCities.Error(exception.message ?: "Unknown error")
+            },
+        )
+
+    override suspend fun getAllCities(): ResultCities =
+        runCatching {
+            dictionary.getAllCities()
         }.fold(
             onSuccess = { cities -> ResultCities.Success(cities) },
             onFailure = { exception ->

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CitySelectionPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CitySelectionPage.kt
@@ -1,6 +1,7 @@
 package my.drivebit.screens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,15 @@ fun CitySelectionPage(mode: CitySelectionMode) {
                 is CitySelectionMode.ForMyCity -> SavedCityViewModelForMyCity(myCityRepository)
             }
         }
+
+    val browseAllCities = mode is CitySelectionMode.ForMyCity
+    LaunchedEffect(browseAllCities) {
+        if (browseAllCities) {
+            viewModel.enableBrowseAllCitiesMode()
+        } else {
+            viewModel.setSearchOnlyMode()
+        }
+    }
 
     val cities by viewModel.cities.collectAsState()
     val error by viewModel.error.collectAsState()


### PR DESCRIPTION
Load Dictionary/cities/all when opening /my-city-selection; filter locally by name/region while typing. Car-creation city picker stays search-only.

Made-with: Cursor