### PR TITLE
feat(documents): STS upload per car, re-upload, and creation step

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarStsDocumentsViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarStsDocumentsViewModel.kt
@@ -1,0 +1,226 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import my.drivebit.network.services.Car
+import my.drivebit.network.services.Document
+import my.drivebit.network.services.Documents
+
+object CarStsDocumentTypes {
+    const val FRONT = "VehicleRegistrationFrontRus"
+    const val BACK = "VehicleRegistrationBackRus"
+
+    val all = setOf(FRONT, BACK)
+}
+
+sealed interface CarStsDocumentsState {
+    data object Idle : CarStsDocumentsState
+
+    data object Loading : CarStsDocumentsState
+
+    data class Uploading(
+        val documentType: String,
+        val documents: List<Document>,
+        val stsSeriesNumber: String?,
+    ) : CarStsDocumentsState
+
+    data class Success(
+        val documents: List<Document>,
+        val stsSeriesNumber: String?,
+    ) : CarStsDocumentsState
+
+    data class Error(
+        val message: String,
+    ) : CarStsDocumentsState
+}
+
+interface CarStsDocumentsViewModel {
+    val state: StateFlow<CarStsDocumentsState>
+
+    fun load()
+
+    fun uploadDocument(
+        documentType: String,
+        fileBytes: ByteArray,
+        fileName: String,
+        contentType: String,
+    )
+}
+
+class CarStsDocumentsViewModelImpl(
+    private val carId: String,
+    private val documents: Documents,
+    private val car: Car,
+    coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : CarStsDocumentsViewModel {
+    private val viewModelScope = coroutineScope
+
+    private val _state = MutableStateFlow<CarStsDocumentsState>(CarStsDocumentsState.Idle)
+
+    override val state: StateFlow<CarStsDocumentsState>
+        get() = _state.asStateFlow()
+
+    override fun load() {
+        viewModelScope.launch {
+            _state.update { CarStsDocumentsState.Loading }
+
+            runCatching {
+                val allDocuments = documents.getDocuments()
+                val myCarCount = runCatching { car.getMyCars().size }.getOrDefault(1)
+                val carDocuments = filterStsDocumentsForCar(allDocuments, carId, myCarCount)
+                val stsSeriesNumber = loadStsSeriesNumber()
+                carDocuments to stsSeriesNumber
+            }.onSuccess { (carDocuments, stsSeriesNumber) ->
+                _state.update {
+                    CarStsDocumentsState.Success(
+                        documents = carDocuments,
+                        stsSeriesNumber = stsSeriesNumber,
+                    )
+                }
+            }.onFailure { e ->
+                val message =
+                    ErrorHandler.extractErrorMessage(
+                        exception = e,
+                        defaultNetworkError = "Ошибка сети",
+                        defaultGenericError = "Не удалось загрузить документы СТС",
+                    )
+                _state.update { CarStsDocumentsState.Error(message) }
+            }
+        }
+    }
+
+    override fun uploadDocument(
+        documentType: String,
+        fileBytes: ByteArray,
+        fileName: String,
+        contentType: String,
+    ) {
+        viewModelScope.launch {
+            val currentDocs = currentDocumentsList()
+            val stsSeriesNumber = currentStsSeriesNumber()
+            _state.update {
+                CarStsDocumentsState.Uploading(
+                    documentType = documentType,
+                    documents = currentDocs,
+                    stsSeriesNumber = stsSeriesNumber,
+                )
+            }
+
+            runCatching {
+                findLatestDocumentByType(currentDocs, documentType)?.let { existing ->
+                    documents.deleteDocument(existing.id)
+                }
+                documents.uploadDocument(
+                    fileBytes = fileBytes,
+                    fileName = fileName,
+                    contentType = contentType,
+                    documentType = documentType,
+                    carId = carId,
+                )
+            }.onSuccess { uploaded ->
+                applyUploadedDocument(uploaded, documentType)
+                load()
+            }.onFailure { e ->
+                val message =
+                    ErrorHandler.extractErrorMessage(
+                        exception = e,
+                        defaultNetworkError = "Ошибка сети",
+                        defaultGenericError = "Не удалось загрузить документ",
+                    )
+                _state.update { CarStsDocumentsState.Error(message) }
+            }
+        }
+    }
+
+    private suspend fun loadStsSeriesNumber(): String? =
+        runCatching {
+            car.getCar(carId).stsSeriesNumber?.trim()?.takeIf { it.isNotEmpty() }
+        }.getOrNull()
+
+    private fun currentDocumentsList(): List<Document> =
+        when (val current = _state.value) {
+            is CarStsDocumentsState.Success -> current.documents
+            is CarStsDocumentsState.Uploading -> current.documents
+            else -> emptyList()
+        }
+
+    private fun currentStsSeriesNumber(): String? =
+        when (val current = _state.value) {
+            is CarStsDocumentsState.Success -> current.stsSeriesNumber
+            is CarStsDocumentsState.Uploading -> current.stsSeriesNumber
+            else -> null
+        }
+
+    private fun findLatestDocumentByType(
+        documents: List<Document>,
+        type: String,
+    ): Document? =
+        documents
+            .filter { it.type == type }
+            .maxByOrNull { it.uploadDate ?: "" }
+
+    private fun applyUploadedDocument(
+        uploaded: Document,
+        documentType: String,
+    ) {
+        val withCarId =
+            if (uploaded.carId.isNullOrBlank()) {
+                uploaded.copy(carId = carId)
+            } else {
+                uploaded
+            }
+        val merged =
+            currentDocumentsList()
+                .filter { it.type != documentType }
+                .plus(withCarId)
+        val stsSeriesNumber = currentStsSeriesNumber()
+        _state.update {
+            CarStsDocumentsState.Success(
+                documents = merged,
+                stsSeriesNumber = stsSeriesNumber,
+            )
+        }
+    }
+
+    companion object {
+        fun filterStsDocumentsForCar(
+            documents: List<Document>,
+            carId: String,
+            myCarCount: Int,
+        ): List<Document> =
+            CarStsDocumentTypes.all.mapNotNull { type ->
+                resolveStsDocumentForCar(
+                    documents = documents,
+                    carId = carId,
+                    type = type,
+                    allowOrphanWithoutCarId = myCarCount <= 1,
+                )
+            }
+
+        private fun resolveStsDocumentForCar(
+            documents: List<Document>,
+            carId: String,
+            type: String,
+            allowOrphanWithoutCarId: Boolean,
+        ): Document? {
+            val active =
+                documents.filter { doc ->
+                    doc.type == type && doc.status != "Expired"
+                }
+            return active.firstOrNull { it.carId?.equals(carId, ignoreCase = true) == true }
+                ?: if (allowOrphanWithoutCarId) {
+                    active
+                        .filter { it.carId.isNullOrBlank() }
+                        .maxByOrNull { it.uploadDate ?: "" }
+                } else {
+                    null
+                }
+        }
+    }
+}

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/DocumentsViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/DocumentsViewModel.kt
@@ -81,11 +81,13 @@ class DocumentsViewModelImpl(
         contentType: String,
     ) {
         viewModelScope.launch {
-            val currentDocs =
-                (_state.value as? DocumentsState.Success)?.documents ?: emptyList()
+            val currentDocs = currentDocumentsList()
             _state.update { DocumentsState.Uploading(documentType, currentDocs) }
 
             runCatching {
+                findLatestDocumentByType(currentDocs, documentType)?.let { existing ->
+                    documents.deleteDocument(existing.id)
+                }
                 documents.uploadDocument(
                     fileBytes = fileBytes,
                     fileName = fileName,
@@ -105,4 +107,19 @@ class DocumentsViewModelImpl(
             }
         }
     }
+
+    private fun currentDocumentsList(): List<Document> =
+        when (val current = _state.value) {
+            is DocumentsState.Success -> current.documents
+            is DocumentsState.Uploading -> current.documents
+            else -> emptyList()
+        }
+
+    private fun findLatestDocumentByType(
+        documents: List<Document>,
+        type: String,
+    ): Document? =
+        documents
+            .filter { it.type == type }
+            .maxByOrNull { it.uploadDate ?: "" }
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
@@ -30,6 +30,8 @@ import my.drivebit.viewmodels.CarMenuViewModelImpl
 import my.drivebit.viewmodels.CarModelViewModel
 import my.drivebit.viewmodels.CarPhotosViewModel
 import my.drivebit.viewmodels.CarPhotosViewModelImpl
+import my.drivebit.viewmodels.CarStsDocumentsViewModel
+import my.drivebit.viewmodels.CarStsDocumentsViewModelImpl
 import my.drivebit.viewmodels.CarSearchViewModel
 import my.drivebit.viewmodels.CarSearchViewModelImpl
 import my.drivebit.viewmodels.ChatDetailViewModel
@@ -404,6 +406,14 @@ val commonViewModelsModule: Module =
         factory<DocumentsViewModel> {
             DocumentsViewModelImpl(
                 documents = get(),
+            )
+        }
+
+        factory<CarStsDocumentsViewModel> { (carId: String) ->
+            CarStsDocumentsViewModelImpl(
+                carId = carId,
+                documents = get(),
+                car = get(),
             )
         }
 

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarStsDocumentsViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarStsDocumentsViewModelTest.kt
@@ -1,0 +1,246 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import my.drivebit.network.services.Car
+import my.drivebit.network.services.CarAddress
+import my.drivebit.network.services.CarCreateRequest
+import my.drivebit.network.services.CarDetailResponse
+import my.drivebit.network.services.CarGeneral
+import my.drivebit.network.services.CarItem
+import my.drivebit.network.services.CarResponse
+import my.drivebit.network.services.CarSearchResponse
+import my.drivebit.network.services.Document
+import my.drivebit.network.services.Documents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CarStsDocumentsViewModelTest {
+    @Test
+    fun `filterStsDocumentsForCar uses STS without carId only for single car owner`() {
+        val carId = "car-1"
+        val docs =
+            listOf(
+                Document(
+                    id = 104,
+                    type = CarStsDocumentTypes.BACK,
+                    carId = null,
+                    status = "Pending",
+                    uploadDate = "2026-05-25T14:45:47Z",
+                ),
+            )
+        assertEquals(1, CarStsDocumentsViewModelImpl.filterStsDocumentsForCar(docs, carId, myCarCount = 1).size)
+        assertEquals(
+            0,
+            CarStsDocumentsViewModelImpl.filterStsDocumentsForCar(docs, carId, myCarCount = 2).size,
+        )
+    }
+
+    @Test
+    fun `filterStsDocumentsForCar matches by carId when API returns CarId`() {
+        val docs =
+            listOf(
+                Document(
+                    id = 1,
+                    type = CarStsDocumentTypes.FRONT,
+                    carId = "car-a",
+                    status = "Pending",
+                ),
+                Document(
+                    id = 2,
+                    type = CarStsDocumentTypes.FRONT,
+                    carId = "car-b",
+                    status = "Pending",
+                ),
+            )
+        val filtered = CarStsDocumentsViewModelImpl.filterStsDocumentsForCar(docs, "car-b", myCarCount = 3)
+        assertEquals(1, filtered.size)
+        assertEquals(2, filtered.first().id)
+    }
+
+    @Test
+    fun `load filters STS documents by carId`() =
+        runTest(StandardTestDispatcher()) {
+            val testScope = CoroutineScope(SupervisorJob() + coroutineContext)
+            val carId = "car-1"
+            val documents =
+                FakeStsDocumentsService(
+                    allDocuments =
+                        listOf(
+                            Document(
+                                id = 1,
+                                type = CarStsDocumentTypes.FRONT,
+                                carId = carId,
+                                status = "Pending",
+                            ),
+                            Document(
+                                id = 2,
+                                type = CarStsDocumentTypes.FRONT,
+                                carId = "car-2",
+                                status = "Pending",
+                            ),
+                            Document(
+                                id = 3,
+                                type = CarStsDocumentTypes.BACK,
+                                carId = carId,
+                                status = "Expired",
+                            ),
+                        ),
+                )
+            val viewModel =
+                CarStsDocumentsViewModelImpl(
+                    carId = carId,
+                    documents = documents,
+                    car = FakeStsCarService(stsSeriesNumber = "77 УН 123456"),
+                    coroutineScope = testScope,
+                )
+
+            viewModel.load()
+            advanceUntilIdle()
+
+            val success = assertIs<CarStsDocumentsState.Success>(viewModel.state.value)
+            assertEquals(1, success.documents.size)
+            assertEquals(1, success.documents.first().id)
+            assertEquals("77 УН 123456", success.stsSeriesNumber)
+            testScope.coroutineContext.cancelChildren()
+        }
+
+    @Test
+    fun `uploadDocument sends carId and deletes existing slot document`() =
+        runTest(StandardTestDispatcher()) {
+            val testScope = CoroutineScope(SupervisorJob() + coroutineContext)
+            val carId = "car-1"
+            val documents =
+                FakeStsDocumentsService(
+                    allDocuments =
+                        listOf(
+                            Document(
+                                id = 10,
+                                type = CarStsDocumentTypes.FRONT,
+                                carId = carId,
+                                status = "Rejected",
+                            ),
+                        ),
+                )
+            val viewModel =
+                CarStsDocumentsViewModelImpl(
+                    carId = carId,
+                    documents = documents,
+                    car = FakeStsCarService(),
+                    coroutineScope = testScope,
+                )
+
+            viewModel.load()
+            advanceUntilIdle()
+
+            viewModel.uploadDocument(
+                documentType = CarStsDocumentTypes.FRONT,
+                fileBytes = byteArrayOf(1),
+                fileName = "sts.jpg",
+                contentType = "image/jpeg",
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(10), documents.deletedIds)
+            assertEquals(carId, documents.lastUploadCarId)
+            assertEquals(1, documents.uploadCount)
+            testScope.coroutineContext.cancelChildren()
+        }
+}
+
+private class FakeStsDocumentsService(
+    var allDocuments: List<Document> = emptyList(),
+) : Documents {
+    val deletedIds = mutableListOf<Int>()
+    var uploadCount = 0
+    var lastUploadCarId: String? = null
+
+    override suspend fun getDocuments(): List<Document> = allDocuments
+
+    override suspend fun uploadDocument(
+        fileBytes: ByteArray,
+        fileName: String,
+        contentType: String,
+        documentType: String,
+        carId: String?,
+    ): Document {
+        uploadCount++
+        lastUploadCarId = carId
+        val doc =
+            Document(
+                id = 99,
+                type = documentType,
+                carId = carId,
+                status = "Pending",
+            )
+        allDocuments = allDocuments.filter { it.type != documentType || it.carId != carId } + doc
+        return doc
+    }
+
+    override suspend fun getDocumentUrl(documentId: Int): String = "https://example.com/$documentId"
+
+    override suspend fun deleteDocument(documentId: Int) {
+        deletedIds += documentId
+        allDocuments = allDocuments.filter { it.id != documentId }
+    }
+}
+
+private class FakeStsCarService(
+    private val stsSeriesNumber: String? = null,
+) : Car {
+    override suspend fun getCar(id: String): CarDetailResponse =
+        CarDetailResponse(
+            id = id,
+            stsSeriesNumber = stsSeriesNumber,
+            general =
+                CarGeneral(
+                    brandName = "",
+                    modelName = "",
+                    vin = "",
+                    seats = 0,
+                    address = CarAddress(geoLat = 0.0, geoLon = 0.0),
+                ),
+        )
+
+    override suspend fun search(
+        cityId: String,
+        dateFrom: String?,
+        dateTo: String?,
+        availableMileagePerDayKmMin: Int?,
+        dailyPriceMin: Int?,
+        dailyPriceMax: Int?,
+        yearMin: Int?,
+        yearMax: Int?,
+        seatsMin: Int?,
+        seatsMax: Int?,
+        bodyTypes: List<String>?,
+        engineTypes: List<String>?,
+        colors: List<String>?,
+        brandId: Int?,
+        modelId: Int?,
+        driveTypes: List<String>?,
+        geoLat: Double?,
+        geoLon: Double?,
+        radiusKm: Double?,
+        page: Int,
+        pageSize: Int,
+    ): CarSearchResponse = CarSearchResponse()
+
+    override suspend fun getMyCars(): List<CarItem> = emptyList()
+
+    override suspend fun createCar(request: CarCreateRequest): CarResponse = CarResponse(id = "")
+
+    override suspend fun createOrUpdateCar(
+        request: CarCreateRequest,
+        carId: String?,
+    ): CarResponse = CarResponse(id = carId.orEmpty())
+
+    override suspend fun deleteCar(carId: String) = Unit
+}

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/DocumentsViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/DocumentsViewModelTest.kt
@@ -1,0 +1,115 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import my.drivebit.network.services.Document
+import my.drivebit.network.services.Documents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DocumentsViewModelTest {
+    @Test
+    fun `uploadDocument deletes existing document of same type before upload`() =
+        runTest(StandardTestDispatcher()) {
+            val testScope = CoroutineScope(SupervisorJob() + coroutineContext)
+            val documents = FakeDocumentsService()
+            val viewModel =
+                DocumentsViewModelImpl(
+                    documents = documents,
+                    coroutineScope = testScope,
+                )
+
+            documents.documents =
+                listOf(
+                    Document(
+                        id = 10,
+                        type = "PassportMainPageRus",
+                        status = "Rejected",
+                        uploadDate = "2026-01-01",
+                    ),
+                )
+            viewModel.load()
+            advanceUntilIdle()
+            assertIs<DocumentsState.Success>(viewModel.state.value)
+
+            viewModel.uploadDocument(
+                documentType = "PassportMainPageRus",
+                fileBytes = byteArrayOf(1),
+                fileName = "passport.jpg",
+                contentType = "image/jpeg",
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf(10), documents.deletedIds)
+            assertEquals(1, documents.uploadCount)
+            assertIs<DocumentsState.Success>(viewModel.state.value)
+            testScope.coroutineContext.cancelChildren()
+        }
+
+    @Test
+    fun `uploadDocument does not delete when slot is empty`() =
+        runTest(StandardTestDispatcher()) {
+            val testScope = CoroutineScope(SupervisorJob() + coroutineContext)
+            val documents = FakeDocumentsService()
+            val viewModel =
+                DocumentsViewModelImpl(
+                    documents = documents,
+                    coroutineScope = testScope,
+                )
+
+            viewModel.load()
+            advanceUntilIdle()
+
+            viewModel.uploadDocument(
+                documentType = "PassportMainPageRus",
+                fileBytes = byteArrayOf(1),
+                fileName = "passport.jpg",
+                contentType = "image/jpeg",
+            )
+            advanceUntilIdle()
+
+            assertEquals(emptyList(), documents.deletedIds)
+            assertEquals(1, documents.uploadCount)
+            testScope.coroutineContext.cancelChildren()
+        }
+}
+
+private class FakeDocumentsService : Documents {
+    var documents: List<Document> = emptyList()
+    val deletedIds = mutableListOf<Int>()
+    var uploadCount = 0
+
+    override suspend fun getDocuments(): List<Document> = documents
+
+    override suspend fun uploadDocument(
+        fileBytes: ByteArray,
+        fileName: String,
+        contentType: String,
+        documentType: String,
+        carId: String?,
+    ): Document {
+        uploadCount++
+        val doc =
+            Document(
+                id = 99,
+                type = documentType,
+                status = "Pending",
+            )
+        documents = documents.filter { it.type != documentType } + doc
+        return doc
+    }
+
+    override suspend fun getDocumentUrl(documentId: Int): String = "https://example.com/$documentId"
+
+    override suspend fun deleteDocument(documentId: Int) {
+        deletedIds += documentId
+        documents = documents.filter { it.id != documentId }
+    }
+}

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
@@ -178,6 +178,7 @@ data class CarDetailResponse(
     val dailyRate21Days: Double? = null,
     val seatsCount: Int? = null,
     val availableMileagePerDayKm: Int? = null,
+    @SerialName("stsSeriesNumber") val stsSeriesNumber: String? = null,
     val insurance: String? = null,
     val insuranceTranslate: String? = null,
     val deposit: Double? = null,

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Documents.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Documents.kt
@@ -3,16 +3,19 @@ package my.drivebit.network.services
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import my.drivebit.network.DEFAULT_BASE_URL
+import my.drivebit.network.consumeResponse
 import my.drivebit.network.parseResponse
-import my.drivebit.utils.extractPathFromApiUrl
-import my.drivebit.utils.isDirectMinioUrl
+import my.drivebit.utils.resolveMinioImageUrlForBrowser
 
 interface Documents {
     suspend fun getDocuments(): List<Document>
@@ -22,15 +25,21 @@ interface Documents {
         fileName: String,
         contentType: String,
         documentType: String,
+        carId: String? = null,
     ): Document
 
     suspend fun getDocumentUrl(documentId: Int): String
+
+    suspend fun deleteDocument(documentId: Int)
 }
 
 @Serializable
 data class Document(
     val id: Int,
     val fileName: String? = null,
+    @SerialName("carId")
+    @JsonNames("carId", "CarId")
+    val carId: String? = null,
     val type: String? = null,
     val status: String? = null,
     val validationResults: String? = null,
@@ -55,6 +64,7 @@ class DocumentsImpl(
         fileName: String,
         contentType: String,
         documentType: String,
+        carId: String?,
     ): Document {
         val url = "${DEFAULT_BASE_URL}Documents/upload"
         val response =
@@ -63,6 +73,7 @@ class DocumentsImpl(
                     MultiPartFormDataContent(
                         formData {
                             append("Type", documentType)
+                            carId?.takeIf { it.isNotBlank() }?.let { append("CarId", it) }
                             append(
                                 "file",
                                 fileBytes,
@@ -82,8 +93,13 @@ class DocumentsImpl(
         val url = "${DEFAULT_BASE_URL}Documents/$documentId/temporary-link"
         val response = httpClient.get(url)
         val urlResponse: DocumentUrlResponse = response.parseResponse()
-        val rawUrl = urlResponse.url
-        return if (isDirectMinioUrl(rawUrl)) extractPathFromApiUrl(rawUrl) else rawUrl
+        return resolveMinioImageUrlForBrowser(urlResponse.url) ?: urlResponse.url
+    }
+
+    override suspend fun deleteDocument(documentId: Int) {
+        val url = "${DEFAULT_BASE_URL}Documents/$documentId"
+        val response = httpClient.delete(url)
+        response.consumeResponse()
     }
 }
 

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/HasPassportRepoTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/HasPassportRepoTest.kt
@@ -24,9 +24,12 @@ private class FakeDocuments : Documents {
         fileName: String,
         contentType: String,
         documentType: String,
+        carId: String?,
     ): Document = throw NotImplementedError()
 
     override suspend fun getDocumentUrl(documentId: Int): String = throw NotImplementedError()
+
+    override suspend fun deleteDocument(documentId: Int) = Unit
 }
 
 private class FakeCarEnumsRepository : CarEnumsRepository {

--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/MinioUrlUtils.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/MinioUrlUtils.kt
@@ -19,3 +19,12 @@ fun extractPathFromApiUrl(apiUrl: String): String {
     val pathStart = apiUrl.indexOf('/', portIndex + 4)
     return if (pathStart >= 0) apiUrl.substring(pathStart) else apiUrl
 }
+
+/** Same-origin path for MinIO URLs (keeps presigned query string). Use in image src behind /privatebct/ nginx or dev proxy. */
+fun resolveMinioImageUrlForBrowser(rawUrl: String?): String? {
+    val trimmed = rawUrl?.trim().orEmpty()
+    if (trimmed.isEmpty()) {
+        return null
+    }
+    return if (isDirectMinioUrl(trimmed)) extractPathFromApiUrl(trimmed) else trimmed
+}

--- a/Utils/src/commonTest/kotlin/my/drivebit/utils/MinioUrlUtilsTest.kt
+++ b/Utils/src/commonTest/kotlin/my/drivebit/utils/MinioUrlUtilsTest.kt
@@ -40,4 +40,15 @@ class MinioUrlUtilsTest {
         assertEquals(u, extractPathFromApiUrl(u))
         assertFalse(isDirectMinioUrl(u))
     }
+
+    @Test
+    fun resolveMinioImageUrlForBrowser_keepsPresignedQueryOnPrivatePath() {
+        val u =
+            "http://157.22.252.70:9000/privatebct/documents/user/file.jpg" +
+                "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc"
+        assertEquals(
+            "/privatebct/documents/user/file.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc",
+            resolveMinioImageUrlForBrowser(u),
+        )
+    }
 }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
@@ -10,6 +10,7 @@ import my.drivebit.screens.AddressInputPage
 import my.drivebit.screens.BodyTypeSelectionPage
 import my.drivebit.screens.CarBrandSelectionPage
 import my.drivebit.screens.CarEditPage
+import my.drivebit.screens.CarStsUploadPage
 import my.drivebit.screens.CarModelSelectionPage
 import my.drivebit.screens.CarPhotosPage
 import my.drivebit.screens.CarPhotosUploadPage
@@ -224,10 +225,13 @@ actual fun App() {
                         },
                     )
                 }
+                currentPath.startsWith("/car-sts-upload") -> {
+                    CarStsUploadPage()
+                }
                 currentPath.startsWith("/license-plate-input") -> {
                     LicensePlateInputPage(
-                        onLicensePlateEntered = {
-                            window.location.href = "/my-cars"
+                        onLicensePlateEntered = { carId ->
+                            window.location.href = "/car-sts-upload?carId=$carId"
                         },
                         onMissingPassport = {
                             window.location.href = "/passport-upload?autoCreate=1"
@@ -366,6 +370,9 @@ actual fun App() {
                     PassportUploadPage(
                         onPassportUploaded = {
                             window.location.href = "/my-cars"
+                        },
+                        onCarCreated = { carId ->
+                            window.location.href = "/car-sts-upload?carId=$carId"
                         },
                     )
                 }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
@@ -463,6 +463,8 @@ fun CarEditPage() {
                                 onSelect = { viewModel.handleIntent(CarEditIntent.SelectInsurance(it)) },
                             )
 
+                            CarStsDocumentsSection(carId = currentState.carId)
+
                             TextInputField(
                                 label = "Доступный пробег в день (км)",
                                 value = formData.availableMileagePerDayKm,

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarStsDocumentsSection.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarStsDocumentsSection.kt
@@ -8,28 +8,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import my.drivebit.components.CenteredFormContainer
-import my.drivebit.components.FormSection
 import my.drivebit.components.Loader
 import my.drivebit.components.NoPhotoPlaceholder
-import my.drivebit.components.PageHeader
-import my.drivebit.components.PageWithLogo
 import my.drivebit.components.TextError
-import my.drivebit.components.TextSmartHeader
 import my.drivebit.design.CSSColors
 import my.drivebit.network.services.Document
 import my.drivebit.network.services.Documents
 import my.drivebit.utils.mapIso8601ToDateString
 import my.drivebit.utils.readAsBytes
 import my.drivebit.utils.resolveMinioImageUrlForBrowser
-import my.drivebit.viewmodels.DocumentsState
-import my.drivebit.viewmodels.DocumentsViewModel
+import my.drivebit.viewmodels.CarStsDocumentTypes
+import my.drivebit.viewmodels.CarStsDocumentsState
+import my.drivebit.viewmodels.CarStsDocumentsViewModel
 import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Button
@@ -38,21 +33,110 @@ import org.jetbrains.compose.web.dom.Img
 import org.jetbrains.compose.web.dom.Input
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
+import org.koin.compose.currentKoinScope
 import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
 
-private data class DocumentSlotConfig(
+private data class StsSlotConfig(
     val documentType: String,
     val title: String,
 )
 
-private val DOCUMENT_SLOTS =
+private val STS_SLOTS =
     listOf(
-        DocumentSlotConfig("PassportMainPageRus", "Первая страница паспорта"),
-        DocumentSlotConfig("PassportSecondaryPageRus", "Вторая страница паспорта"),
-        DocumentSlotConfig("DriverLicense", "Водительское удостоверение"),
+        StsSlotConfig(CarStsDocumentTypes.FRONT, "Лицевая сторона СТС"),
+        StsSlotConfig(CarStsDocumentTypes.BACK, "Оборотная сторона СТС"),
     )
 
-private fun findDocumentByType(
+@Composable
+fun CarStsDocumentsSection(carId: String) {
+    val koinScope = currentKoinScope()
+    val viewModel: CarStsDocumentsViewModel =
+        remember(carId) {
+            koinScope.get { parametersOf(carId) }
+        }
+
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(carId) {
+        viewModel.load()
+    }
+
+    Div({
+        style {
+            marginTop(8.px)
+            marginBottom(8.px)
+            fontSize(18.px)
+            fontWeight("600")
+            color(CSSColors.Black)
+        }
+    }) {
+        Text("Свидетельство о регистрации (СТС)")
+    }
+
+    when (val currentState = state) {
+        is CarStsDocumentsState.Idle,
+        is CarStsDocumentsState.Loading,
+        -> Loader()
+
+        is CarStsDocumentsState.Error -> {
+            TextError(currentState.message)
+        }
+
+        is CarStsDocumentsState.Uploading -> {
+            currentState.stsSeriesNumber?.let { sts ->
+                StsSeriesNumberHint(sts)
+            }
+            renderStsSlots(
+                documents = currentState.documents,
+                uploadingType = currentState.documentType,
+                viewModel = viewModel,
+            )
+        }
+
+        is CarStsDocumentsState.Success -> {
+            currentState.stsSeriesNumber?.let { sts ->
+                StsSeriesNumberHint(sts)
+            }
+            renderStsSlots(
+                documents = currentState.documents,
+                uploadingType = null,
+                viewModel = viewModel,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StsSeriesNumberHint(stsSeriesNumber: String) {
+    Div({
+        style {
+            marginBottom(12.px)
+            fontSize(14.px)
+            color(CSSColors.Gray600)
+        }
+    }) {
+        Text("Серия и номер СТС: $stsSeriesNumber")
+    }
+}
+
+@Composable
+private fun renderStsSlots(
+    documents: List<Document>,
+    uploadingType: String?,
+    viewModel: CarStsDocumentsViewModel,
+) {
+    STS_SLOTS.forEach { slot ->
+        StsDocumentSlot(
+            slotConfig = slot,
+            document = findStsDocumentByType(documents, slot.documentType),
+            isUploading = uploadingType == slot.documentType,
+            viewModel = viewModel,
+        )
+    }
+}
+
+private fun findStsDocumentByType(
     documents: List<Document>,
     type: String,
 ): Document? =
@@ -60,129 +144,17 @@ private fun findDocumentByType(
         .filter { it.type == type }
         .maxByOrNull { it.uploadDate ?: "" }
 
-private fun getStatusLabel(status: String?): String =
-    when (status) {
-        "Validated" -> "Одобрен"
-        "Pending" -> "Ожидает"
-        "UnderReview" -> "На проверке"
-        "Rejected" -> "Отклонён"
-        "Expired" -> "Просрочен"
-        else -> "Не загружен"
-    }
-
-private fun getStatusColor(status: String?) =
-    when (status) {
-        "Validated" -> CSSColors.Green
-        "Rejected" -> CSSColors.Red
-        else -> CSSColors.Gray600
-    }
-
-private fun canReupload(document: Document?): Boolean {
+private fun canReuploadSts(document: Document?): Boolean {
     if (document == null) return true
     return document.status != "Validated"
 }
 
 @Composable
-private fun renderDocumentSlots(
-    documents: List<Document>,
-    uploadingType: String?,
-    viewModel: DocumentsViewModel,
-) {
-    Div({
-        style {
-            marginBottom(24.px)
-            fontSize(18.px)
-            fontWeight("600")
-            color(CSSColors.Black)
-        }
-    }) {
-        Text("Паспорт")
-    }
-    DOCUMENT_SLOTS.take(2).forEach { slot ->
-        DocumentSlot(
-            slotConfig = slot,
-            document = findDocumentByType(documents, slot.documentType),
-            isUploading = uploadingType == slot.documentType,
-            viewModel = viewModel,
-        )
-    }
-    Div({
-        style {
-            marginTop(32.px)
-            marginBottom(24.px)
-            fontSize(18.px)
-            fontWeight("600")
-            color(CSSColors.Black)
-        }
-    }) {
-        Text("Водительское удостоверение")
-    }
-    DOCUMENT_SLOTS.last().let { slot ->
-        DocumentSlot(
-            slotConfig = slot,
-            document = findDocumentByType(documents, slot.documentType),
-            isUploading = uploadingType == slot.documentType,
-            viewModel = viewModel,
-        )
-    }
-}
-
-@Composable
-fun DocumentsPage() {
-    val viewModel: DocumentsViewModel = koinInject()
-    val state by viewModel.state.collectAsState()
-
-    LaunchedEffect(Unit) {
-        viewModel.load()
-    }
-
-    PageWithLogo {
-        CenteredFormContainer {
-            PageHeader {
-                TextSmartHeader("Мои документы")
-            }
-
-            FormSection {
-                when (val currentState = state) {
-                    is DocumentsState.Idle -> {
-                        Loader()
-                    }
-
-                    is DocumentsState.Loading -> {
-                        Loader()
-                    }
-
-                    is DocumentsState.Uploading -> {
-                        renderDocumentSlots(
-                            documents = currentState.documents,
-                            uploadingType = currentState.documentType,
-                            viewModel = viewModel,
-                        )
-                    }
-
-                    is DocumentsState.Error -> {
-                        TextError(currentState.message)
-                    }
-
-                    is DocumentsState.Success -> {
-                        renderDocumentSlots(
-                            documents = currentState.documents,
-                            uploadingType = null,
-                            viewModel = viewModel,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DocumentSlot(
-    slotConfig: DocumentSlotConfig,
+private fun StsDocumentSlot(
+    slotConfig: StsSlotConfig,
     document: Document?,
     isUploading: Boolean,
-    viewModel: DocumentsViewModel,
+    viewModel: CarStsDocumentsViewModel,
 ) {
     val doc = document
     val documentsService: Documents = koinInject()
@@ -202,14 +174,15 @@ private fun DocumentSlot(
                 documentsService.getDocumentUrl(doc.id)
             }.onSuccess { url ->
                 documentPreviewUrl = url
-            }.onFailure { /* ignore - will show placeholder */ }
+            }
         } else {
             documentPreviewUrl = null
         }
     }
-    val fileInputId = remember { "doc-upload-${slotConfig.documentType}-${kotlin.random.Random.nextInt()}" }
+
+    val fileInputId = remember { "sts-upload-${slotConfig.documentType}-${kotlin.random.Random.nextInt()}" }
     val status = doc?.status
-    val showUpload = canReupload(document)
+    val showUpload = canReuploadSts(document)
 
     DisposableEffect(fileInputId) {
         val inputElement = kotlinx.browser.document.getElementById(fileInputId) as? org.w3c.dom.HTMLInputElement
@@ -263,10 +236,10 @@ private fun DocumentSlot(
             Span({
                 style {
                     fontSize(14.px)
-                    color(getStatusColor(status))
+                    color(stsStatusColor(status))
                 }
             }) {
-                Text(getStatusLabel(status))
+                Text(stsStatusLabel(status))
             }
         }
 
@@ -333,7 +306,7 @@ private fun DocumentSlot(
             }
         }
 
-        if (errorMessage != null) {
+        errorMessage?.let { message ->
             Div({
                 style {
                     marginBottom(8.px)
@@ -341,7 +314,7 @@ private fun DocumentSlot(
                     color(CSSColors.Red)
                 }
             }) {
-                Text(errorMessage ?: "")
+                Text(message)
             }
         }
 
@@ -392,13 +365,30 @@ private fun DocumentSlot(
                     color(CSSColors.Gray600)
                 }
             }) {
-                Text("Загружено: ${formatDate(uploadDate)}")
+                Text("Загружено: ${formatStsDate(uploadDate)}")
             }
         }
     }
 }
 
-private fun formatDate(dateString: String): String =
+private fun stsStatusLabel(status: String?): String =
+    when (status) {
+        "Validated" -> "Одобрен"
+        "Pending" -> "Ожидает"
+        "UnderReview" -> "На проверке"
+        "Rejected" -> "Отклонён"
+        "Expired" -> "Просрочен"
+        else -> "Не загружен"
+    }
+
+private fun stsStatusColor(status: String?) =
+    when (status) {
+        "Validated" -> CSSColors.Green
+        "Rejected" -> CSSColors.Red
+        else -> CSSColors.Gray600
+    }
+
+private fun formatStsDate(dateString: String): String =
     runCatching {
         mapIso8601ToDateString(dateString)
     }.getOrDefault(dateString)

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarStsUploadPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/CarStsUploadPage.kt
@@ -1,0 +1,82 @@
+package my.drivebit.screens
+
+import androidx.compose.runtime.Composable
+import kotlinx.browser.window
+import my.drivebit.components.ActionButton
+import my.drivebit.components.CenteredFormContainer
+import my.drivebit.components.FormSection
+import my.drivebit.components.PageHeader
+import my.drivebit.components.PageWithLogo
+import my.drivebit.components.Row
+import my.drivebit.components.TextError
+import my.drivebit.components.TextSmartHeader
+import my.drivebit.design.CSSColors
+import my.drivebit.utils.getUrlParameter
+import org.jetbrains.compose.web.css.JustifyContent
+import org.jetbrains.compose.web.css.color
+import org.jetbrains.compose.web.css.fontSize
+import org.jetbrains.compose.web.css.marginBottom
+import org.jetbrains.compose.web.css.marginTop
+import org.jetbrains.compose.web.css.maxWidth
+import org.jetbrains.compose.web.css.percent
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.css.width
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun CarStsUploadPage(
+    onContinue: () -> Unit = {
+        window.location.href = "/my-cars"
+    },
+) {
+    val carId = getUrlParameter("carId")
+
+    PageWithLogo {
+        CenteredFormContainer {
+            PageHeader {
+                TextSmartHeader("СТС автомобиля")
+            }
+
+            FormSection {
+                if (carId.isBlank()) {
+                    TextError("Не указан ID автомобиля")
+                } else {
+                    Div({
+                        style {
+                            marginTop(0.px)
+                            marginBottom(16.px)
+                            fontSize(14.px)
+                            color(CSSColors.Gray600)
+                        }
+                    }) {
+                        Text(
+                            "Загрузите обе стороны свидетельства о регистрации. " +
+                                "Можно пропустить и добавить позже в разделе «Управление автомобилем».",
+                        )
+                    }
+
+                    CarStsDocumentsSection(carId = carId)
+
+                    Row(
+                        justifyContent = JustifyContent.Center,
+                        modifier = { marginTop(24.px) },
+                    ) {
+                        Div({
+                            style {
+                                maxWidth(240.px)
+                                width(100.percent)
+                            }
+                        }) {
+                            ActionButton(
+                                enabledColor = CSSColors.Blue,
+                                text = "Продолжить",
+                                onClick = onContinue,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/LicensePlateInputPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/LicensePlateInputPage.kt
@@ -28,7 +28,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun LicensePlateInputPage(
-    onLicensePlateEntered: () -> Unit = {},
+    onLicensePlateEntered: (carId: String) -> Unit = {},
     onMissingPassport: () -> Unit = {},
     onBack: () -> Unit = {},
 ) {
@@ -52,14 +52,14 @@ fun LicensePlateInputPage(
     )
 
     LaunchedEffect(createCarState) {
-        when (createCarState) {
+        when (val current = createCarState) {
             CreateCarFromDailyRateState.MissingPassport -> {
                 createCarViewModel.reset()
                 onMissingPassport()
             }
             is CreateCarFromDailyRateState.Success -> {
                 createCarViewModel.reset()
-                onLicensePlateEntered()
+                onLicensePlateEntered(current.carId)
             }
             else -> Unit
         }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/screens/PassportUploadPage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/screens/PassportUploadPage.kt
@@ -35,7 +35,10 @@ import org.jetbrains.compose.web.dom.Text
 import org.koin.compose.koinInject
 
 @Composable
-fun PassportUploadPage(onPassportUploaded: () -> Unit = {}) {
+fun PassportUploadPage(
+    onPassportUploaded: () -> Unit = {},
+    onCarCreated: (carId: String) -> Unit = { onPassportUploaded() },
+) {
     val viewModel: PassportUploadViewModel = koinInject()
     val state by viewModel.state.collectAsState()
     val buttonViewModel = createButtonViewModel()
@@ -71,7 +74,7 @@ fun PassportUploadPage(onPassportUploaded: () -> Unit = {}) {
     }
 
     LaunchedEffect(state) {
-        when (state) {
+        when (val current = state) {
             is PassportUploadState.Success -> {
                 if (autoCreate == "1") {
                     viewModel.createCar()
@@ -82,7 +85,7 @@ fun PassportUploadPage(onPassportUploaded: () -> Unit = {}) {
             }
             is PassportUploadState.CarCreated -> {
                 viewModel.reset()
-                onPassportUploaded()
+                onCarCreated(current.carId)
             }
             else -> Unit
         }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/web/CityPathRouting.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/web/CityPathRouting.kt
@@ -32,6 +32,7 @@ val RESERVED_FIRST_SEGMENTS: Set<String> =
         "payment-failure",
         "download-booking-contract",
         "car-edit",
+        "car-sts-upload",
         "car-photos-gallery",
         "car-photos-upload",
         "car-photos",

--- a/composeApp/webpack.config.d/webpack.config.js
+++ b/composeApp/webpack.config.d/webpack.config.js
@@ -24,5 +24,12 @@ config.devServer.proxy = [
         secure: false,
         logLevel: 'debug',
     },
+    {
+        context: ['/privatebct'],
+        target: 'http://157.22.252.70:9000',
+        changeOrigin: true,
+        secure: false,
+        logLevel: 'debug',
+    },
 ];
 


### PR DESCRIPTION
Add STS slots on car edit and post-create flow, delete-before-reupload for documents, privatebct dev proxy for previews, and stricter STS filtering when the user has multiple cars until the API returns carId.