### PR TITLE
fix(web): load full brand/model dictionary when creating a car

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarBrandSelectionPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarBrandSelectionPage.kt
@@ -31,7 +31,7 @@ fun CarBrandSelectionPage(
     var inputValue by remember { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
-        viewModel.loadBrands(existingInFleetOnly = true)
+        viewModel.loadBrands()
     }
 
     PageWithLogo {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarModelSelectionPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarModelSelectionPage.kt
@@ -37,7 +37,7 @@ fun CarModelSelectionPage(
         val brandId = brandIdParam.toIntOrNull()
         if (brandId != null) {
             localError = null
-            viewModel.loadModels(brandId, existingInFleetOnly = true)
+            viewModel.loadModels(brandId)
         } else {
             localError = "Бренд не выбран"
         }


### PR DESCRIPTION
Use the complete Dictionary endpoints on car creation screens so owners can select models like Megane that are not yet listed on the site.