### PR TITLE
Contract signing and fix HTTPS contract download

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ChatDetailViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ChatDetailViewModel.kt
@@ -21,8 +21,11 @@ import my.drivebit.network.services.PayBookingResult
 import my.drivebit.network.services.Payment
 import my.drivebit.network.services.SendMessageRequest
 import my.drivebit.network.services.checkoutBooking
+import my.drivebit.network.services.contractBookingIdForAction
 import my.drivebit.network.services.leaveReviewBookingIdForAction
 import my.drivebit.network.services.payBookingIdForAction
+import my.drivebit.network.services.SignContractChatRole
+import my.drivebit.network.services.signContractChatRole
 import my.drivebit.repositories.ParticipantAvatarCache
 import my.drivebit.utils.safeLaunchWithErrorHandler
 
@@ -46,6 +49,8 @@ interface ChatDetailViewModel {
 
     val isPaying: StateFlow<Boolean>
 
+    val signActionInProgress: StateFlow<Set<String>>
+
     val payEffects: SharedFlow<ChatPayEffect>
 
     fun loadChat()
@@ -66,6 +71,11 @@ interface ChatDetailViewModel {
         bookingId: String,
         returnUrl: String,
         failUrl: String,
+    )
+
+    fun signContract(
+        bookingId: String,
+        counterpartyUserId: String,
     )
 }
 
@@ -97,6 +107,9 @@ class ChatDetailViewModelImpl(
 
     private val _isPaying = MutableStateFlow(false)
     override val isPaying: StateFlow<Boolean> = _isPaying.asStateFlow()
+
+    private val _signActionInProgress = MutableStateFlow<Set<String>>(emptySet())
+    override val signActionInProgress: StateFlow<Set<String>> = _signActionInProgress.asStateFlow()
 
     private val _payEffects = MutableSharedFlow<ChatPayEffect>(extraBufferCapacity = 1)
     override val payEffects: SharedFlow<ChatPayEffect> = _payEffects.asSharedFlow()
@@ -140,7 +153,45 @@ class ChatDetailViewModelImpl(
             val result = chat.getMessages(chatId, limit = 50)
             val loaded = (result.messages ?: emptyList()).sortedBy { it.createdAt }
             _messages.value = loaded
-            refreshBookingsForPayActions(loaded)
+            refreshBookingsForMessageActions(loaded)
+        }
+    }
+
+    override fun signContract(
+        bookingId: String,
+        counterpartyUserId: String,
+    ) {
+        if (bookingId.isBlank() || bookingId in _signActionInProgress.value) return
+        val dto = _bookingPaymentById.value[bookingId] ?: return
+        val role = dto.signContractChatRole(counterpartyUserId) ?: return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { false },
+            setLoading = { },
+            setError = { message ->
+                coroutineScope.launch {
+                    _payEffects.emit(ChatPayEffect.ShowInfo(message ?: "Не удалось подписать договор"))
+                }
+            },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось подписать договор",
+                )
+            },
+        ) {
+            _signActionInProgress.update { it + bookingId }
+            try {
+                val updated =
+                    when (role) {
+                        SignContractChatRole.Owner -> booking.signContractAsOwner(bookingId)
+                        SignContractChatRole.Renter -> booking.signContractAsRenter(bookingId)
+                    }
+                _bookingPaymentById.update { current -> current + (bookingId to updated) }
+            } finally {
+                _signActionInProgress.update { it - bookingId }
+            }
         }
     }
 
@@ -202,13 +253,14 @@ class ChatDetailViewModelImpl(
         )
     }
 
-    private fun refreshBookingsForPayActions(messages: List<MessageDto>) {
+    private fun refreshBookingsForMessageActions(messages: List<MessageDto>) {
         val bookingIds =
             messages
                 .flatMap { message ->
                     listOfNotNull(
                         message.payBookingIdForAction(),
                         message.leaveReviewBookingIdForAction(),
+                        message.contractBookingIdForAction(),
                     )
                 }.distinct()
         if (bookingIds.isEmpty()) return
@@ -246,7 +298,7 @@ class ChatDetailViewModelImpl(
                             val refreshed = chat.getMessages(chatId, limit = 50)
                             val loaded = (refreshed.messages ?: emptyList()).sortedBy { it.createdAt }
                             _messages.value = loaded
-                            refreshBookingsForPayActions(loaded)
+                            refreshBookingsForMessageActions(loaded)
                         }
                     }
                     is PayBookingResult.Failed ->

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
@@ -25,6 +25,8 @@ interface MyBookingsAsOwnerViewModel {
     fun confirmBooking(bookingId: String)
 
     fun declineBooking(bookingId: String)
+
+    fun signContractAsOwner(bookingId: String)
 }
 
 class MyBookingsAsOwnerViewModelImpl(
@@ -117,6 +119,32 @@ class MyBookingsAsOwnerViewModelImpl(
             _actionInProgress.update { it + bookingId }
             try {
                 booking.declineAsOwner(bookingId)
+                val result = booking.getMyAsOwner()
+                _bookings.value = result
+            } finally {
+                _actionInProgress.update { it - bookingId }
+            }
+        }
+    }
+
+    override fun signContractAsOwner(bookingId: String) {
+        if (bookingId in _actionInProgress.value) return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { false },
+            setLoading = { },
+            setError = { _error.value = it },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось подписать договор",
+                )
+            },
+        ) {
+            _actionInProgress.update { it + bookingId }
+            try {
+                booking.signContractAsOwner(bookingId)
                 val result = booking.getMyAsOwner()
                 _bookings.value = result
             } finally {

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsRenterViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsRenterViewModel.kt
@@ -29,6 +29,8 @@ interface MyBookingsAsRenterViewModel {
 
     fun loadBookings()
 
+    fun refreshBookings()
+
     fun payBooking(
         bookingId: String,
         returnUrl: String,
@@ -84,6 +86,16 @@ class MyBookingsAsRenterViewModelImpl(
         ) {
             val result = booking.getMyAsRenter()
             _bookings.value = result
+        }
+    }
+
+    override fun refreshBookings() {
+        coroutineScope.launch {
+            runCatching {
+                val result = booking.getMyAsRenter()
+                _bookings.value = result
+                _error.value = null
+            }
         }
     }
 

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsRenterViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsRenterViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import my.drivebit.network.services.Booking
 import my.drivebit.network.services.BookingCheckoutKind
@@ -23,6 +24,7 @@ interface MyBookingsAsRenterViewModel {
     val isLoading: StateFlow<Boolean>
     val error: StateFlow<String?>
     val isPaying: StateFlow<Boolean>
+    val actionInProgress: StateFlow<Set<String>>
     val payEffects: SharedFlow<ChatPayEffect>
 
     fun loadBookings()
@@ -38,6 +40,8 @@ interface MyBookingsAsRenterViewModel {
         returnUrl: String,
         failUrl: String,
     )
+
+    fun signContractAsRenter(bookingId: String)
 }
 
 class MyBookingsAsRenterViewModelImpl(
@@ -56,6 +60,9 @@ class MyBookingsAsRenterViewModelImpl(
 
     private val _isPaying = MutableStateFlow(false)
     override val isPaying: StateFlow<Boolean> = _isPaying.asStateFlow()
+
+    private val _actionInProgress = MutableStateFlow<Set<String>>(emptySet())
+    override val actionInProgress: StateFlow<Set<String>> = _actionInProgress.asStateFlow()
 
     private val _payEffects = MutableSharedFlow<ChatPayEffect>(extraBufferCapacity = 1)
     override val payEffects: SharedFlow<ChatPayEffect> = _payEffects.asSharedFlow()
@@ -131,6 +138,32 @@ class MyBookingsAsRenterViewModelImpl(
                 }
             } finally {
                 _isPaying.value = false
+            }
+        }
+    }
+
+    override fun signContractAsRenter(bookingId: String) {
+        if (bookingId in _actionInProgress.value) return
+
+        coroutineScope.safeLaunchWithErrorHandler(
+            isLoading = { false },
+            setLoading = { },
+            setError = { _error.value = it },
+            errorHandler = { e ->
+                ErrorHandler.extractErrorMessage(
+                    exception = e,
+                    defaultNetworkError = "Ошибка сети",
+                    defaultGenericError = "Не удалось подписать договор",
+                )
+            },
+        ) {
+            _actionInProgress.update { it + bookingId }
+            try {
+                booking.signContractAsRenter(bookingId)
+                val result = booking.getMyAsRenter()
+                _bookings.value = result
+            } finally {
+                _actionInProgress.update { it - bookingId }
             }
         }
     }

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/RentViewModelTest.kt
@@ -73,6 +73,12 @@ private class FakeBooking(
     override suspend fun getContract(bookingId: String): my.drivebit.network.services.GetBookingContractResult =
         throw NotImplementedError()
 
+    override suspend fun signContractAsOwner(bookingId: String): my.drivebit.network.services.BookingDTO =
+        throw NotImplementedError()
+
+    override suspend fun signContractAsRenter(bookingId: String): my.drivebit.network.services.BookingDTO =
+        throw NotImplementedError()
+
     override suspend fun createAsRenter(request: my.drivebit.network.services.CreateBookingRequest) =
         my.drivebit.network.services.BookingDTO(
             id = "booking-1",
@@ -90,6 +96,7 @@ private class FakeBooking(
             totalAmount = 0.0,
             status = createStatus,
             statusTranslate = null,
+            canPayFullAmount = createStatus.equals("Confirmed", ignoreCase = true),
             createdAt = "2025-02-16T10:00:00Z",
         )
 }

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/ChatDetailPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/ChatDetailPage.kt
@@ -22,6 +22,7 @@ import my.drivebit.components.ToolbarBackArrow
 import my.drivebit.design.CSSColors
 import my.drivebit.network.services.BookingDTO
 import my.drivebit.network.services.MessageDto
+import my.drivebit.network.services.canShowSignContractInChat
 import my.drivebit.network.services.contractBookingIdForAction
 import my.drivebit.network.services.contractDownloadPagePath
 import my.drivebit.network.services.isLeaveReviewForCarAction
@@ -82,6 +83,7 @@ fun ChatDetailPage() {
     val error by viewModel.error.collectAsState()
     val isSending by viewModel.isSending.collectAsState()
     val isPaying by viewModel.isPaying.collectAsState()
+    val signActionInProgress by viewModel.signActionInProgress.collectAsState()
     val bookingPaymentById by viewModel.bookingPaymentById.collectAsState()
 
     LaunchedEffect(chatId) {
@@ -165,6 +167,7 @@ fun ChatDetailPage() {
                                         bookingForPay = bookingIdForPay?.let { bookingPaymentById[it] },
                                         bookingById = bookingPaymentById,
                                         isPaying = isPaying,
+                                        signActionInProgress = signActionInProgress,
                                         onPrepayBooking = { bookingId ->
                                             val origin = window.location.origin
                                             viewModel.prepayBooking(
@@ -179,6 +182,12 @@ fun ChatDetailPage() {
                                                 bookingId = bookingId,
                                                 returnUrl = "$origin/payment-success",
                                                 failUrl = "$origin/payment-failure",
+                                            )
+                                        },
+                                        onSignContract = { bookingId, counterpartyUserId ->
+                                            viewModel.signContract(
+                                                bookingId = bookingId,
+                                                counterpartyUserId = counterpartyUserId,
                                             )
                                         },
                                     )
@@ -262,8 +271,10 @@ private fun MessageBubble(
     bookingForPay: BookingDTO? = null,
     bookingById: Map<String, BookingDTO> = emptyMap(),
     isPaying: Boolean = false,
+    signActionInProgress: Set<String> = emptySet(),
     onPrepayBooking: (String) -> Unit = {},
     onPayBooking: (String) -> Unit = {},
+    onSignContract: (bookingId: String, counterpartyUserId: String) -> Unit = { _, _ -> },
 ) {
     val isSystemMessage = message.isSystemMessage
     val senderId = message.sender?.id
@@ -285,10 +296,22 @@ private fun MessageBubble(
         val showReviewForRenter = message.shouldShowLeaveReviewForRenter()
         val payButtonVm = createButtonViewModel()
         val contractButtonVm = createButtonViewModel()
+        val signContractButtonVm = createButtonViewModel()
         val reviewCarButtonVm = createButtonViewModel()
         val reviewRenterButtonVm = createButtonViewModel()
+        val bookingForContract = bookingIdForContract?.let { bookingById[it] }
+        val showSignContract =
+            bookingIdForContract != null &&
+                participantId != null &&
+                bookingForContract?.canShowSignContractInChat(participantId) == true
+        val isSigningContract = bookingIdForContract != null && bookingIdForContract in signActionInProgress
         LaunchedEffect(isPaying) {
             payButtonVm.setState(if (isPaying) ButtonState.Loading else ButtonState.Enabled)
+        }
+        LaunchedEffect(isSigningContract) {
+            signContractButtonVm.setState(
+                if (isSigningContract) ButtonState.Loading else ButtonState.Enabled,
+            )
         }
         LaunchedEffect(reviewCarId) {
             reviewCarButtonVm.setState(
@@ -350,6 +373,23 @@ private fun MessageBubble(
                             viewModel = contractButtonVm,
                             onClick = {
                                 window.location.href = contractDownloadPagePath(bookingIdForContract)
+                            },
+                        )
+                    }
+                }
+                if (showSignContract) {
+                    Div({
+                        style {
+                            width(100.percent)
+                            maxWidth(280.px)
+                        }
+                    }) {
+                        ActionButton(
+                            text = if (isSigningContract) "Подписание..." else "Подписать договор",
+                            enabledColor = CSSColors.Blue,
+                            viewModel = signContractButtonVm,
+                            onClick = {
+                                onSignContract(bookingIdForContract!!, participantId!!)
                             },
                         )
                     }

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/DownloadBookingContractPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/DownloadBookingContractPage.kt
@@ -22,6 +22,7 @@ import my.drivebit.utils.encodeUrlParameter
 import my.drivebit.utils.getUrlParameter
 import my.drivebit.utils.mapIso8601ToDateString
 import my.drivebit.utils.mapIso8601ToTimeString
+import my.drivebit.network.services.browserDownloadUrl
 import my.drivebit.viewmodels.BookingContractUiState
 import my.drivebit.viewmodels.BookingContractViewModel
 import org.jetbrains.compose.web.css.*
@@ -168,7 +169,7 @@ fun DownloadBookingContractPage() {
                                 property("align-self", "flex-start")
                             }
                             onClick {
-                                window.open(contract.downloadUrl, "_blank")
+                                window.open(contract.browserDownloadUrl(), "_blank")
                             }
                         }) {
                             Text("Скачать договор")

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyBookingsPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyBookingsPage.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import kotlinx.coroutines.delay
 import kotlinx.datetime.Instant
 import my.drivebit.components.CenteredFormContainer
 import my.drivebit.components.Column
@@ -46,6 +47,10 @@ fun MyBookingsPage() {
 
     LaunchedEffect(Unit) {
         viewModel.loadBookings()
+        while (true) {
+            delay(30_000)
+            viewModel.refreshBookings()
+        }
     }
 
     PageWithLogo {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyBookingsPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyBookingsPage.kt
@@ -18,6 +18,7 @@ import my.drivebit.components.TextSmartHeader
 import my.drivebit.design.CSSColors
 import my.drivebit.navigation.LocalNavigationController
 import my.drivebit.network.services.BookingDTO
+import my.drivebit.network.services.canShowSignContractAsRenter
 import my.drivebit.network.services.renterFullOrBalanceAmountRub
 import my.drivebit.network.services.renterFullOrBalancePaymentLabel
 import my.drivebit.network.services.prepaymentButtonLabel
@@ -41,6 +42,7 @@ fun MyBookingsPage() {
     val bookings by viewModel.bookings.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
+    val actionInProgress by viewModel.actionInProgress.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.loadBookings()
@@ -72,6 +74,7 @@ fun MyBookingsPage() {
                             bookings.forEach { booking ->
                                 BookingItemCard(
                                     booking = booking,
+                                    isActionInProgress = booking.id in actionInProgress,
                                     onLeaveReview = {
                                         navigationController?.navigateTo("/leave-review?carId=${booking.carId}")
                                     },
@@ -83,6 +86,7 @@ fun MyBookingsPage() {
                                             "/payment?bookingId=${booking.id}&mode=prepay",
                                         )
                                     },
+                                    onSignContract = { viewModel.signContractAsRenter(booking.id) },
                                     onDownloadContract = {
                                         navigationController?.navigateTo(
                                             "/download-booking-contract?bookingId=${booking.id}",
@@ -101,9 +105,11 @@ fun MyBookingsPage() {
 @Composable
 private fun BookingItemCard(
     booking: BookingDTO,
+    isActionInProgress: Boolean = false,
     onLeaveReview: () -> Unit,
     onPay: () -> Unit,
     onPrepay: () -> Unit,
+    onSignContract: () -> Unit,
     onDownloadContract: () -> Unit,
 ) {
     val ownerName = booking.ownerName?.takeIf { it.isNotBlank() } ?: "Владелец"
@@ -129,6 +135,7 @@ private fun BookingItemCard(
     val canLeaveReview = booking.status.equals("Completed", ignoreCase = true)
     val canPay = booking.statusAllowsRenterPayment()
     val canDownloadContract = booking.statusAllowsContractDownload()
+    val canSignContract = booking.canShowSignContractAsRenter()
     val fullPaymentLabel =
         "${booking.renterFullOrBalancePaymentLabel()} (${booking.renterFullOrBalanceAmountRub()} ₽)"
 
@@ -208,7 +215,7 @@ private fun BookingItemCard(
             }
         }
 
-        if (canPay || booking.canPayPrepayment || canLeaveReview || canDownloadContract) {
+        if (canPay || booking.canPayPrepayment || canLeaveReview || canDownloadContract || canSignContract) {
             Row(
                 justifyContent = JustifyContent.FlexStart,
                 gap = 8.px,
@@ -263,6 +270,26 @@ private fun BookingItemCard(
                         onClick { onDownloadContract() }
                     }) {
                         Text("Договор")
+                    }
+                }
+                if (canSignContract) {
+                    Button({
+                        style {
+                            padding(8.px, 16.px)
+                            backgroundColor(CSSColors.Blue)
+                            color(CSSColors.White)
+                            border(0.px)
+                            borderRadius(8.px)
+                            fontSize(14.px)
+                            fontWeight("600")
+                            cursor(if (isActionInProgress) "default" else "pointer")
+                            property("opacity", if (isActionInProgress) "0.6" else "1")
+                        }
+                        if (!isActionInProgress) {
+                            onClick { onSignContract() }
+                        }
+                    }) {
+                        Text(if (isActionInProgress) "Подписание..." else "Подписать договор")
                     }
                 }
                 if (canLeaveReview) {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyDealsPage.kt
@@ -19,6 +19,7 @@ import my.drivebit.components.TextSmartHeader
 import my.drivebit.design.CSSColors
 import my.drivebit.navigation.LocalNavigationController
 import my.drivebit.network.services.BookingDTO
+import my.drivebit.network.services.canShowSignContractAsOwner
 import my.drivebit.network.services.statusAllowsContractDownload
 import my.drivebit.utils.formatRelativeTime
 import my.drivebit.utils.mapIso8601ToDateString
@@ -77,6 +78,7 @@ fun MyDealsPage() {
                                     isActionInProgress = booking.id in actionInProgress,
                                     onConfirm = { viewModel.confirmBooking(booking.id) },
                                     onDecline = { viewModel.declineBooking(booking.id) },
+                                    onSignContract = { viewModel.signContractAsOwner(booking.id) },
                                     onDownloadContract = {
                                         navigationController?.navigateTo(
                                             "/download-booking-contract?bookingId=${booking.id}",
@@ -98,6 +100,7 @@ private fun DealItemCard(
     isActionInProgress: Boolean,
     onConfirm: () -> Unit,
     onDecline: () -> Unit,
+    onSignContract: () -> Unit,
     onDownloadContract: () -> Unit,
 ) {
     val renterName = booking.renterName?.takeIf { it.isNotBlank() } ?: "Арендатор"
@@ -124,6 +127,7 @@ private fun DealItemCard(
         booking.status.equals("Pending", ignoreCase = true) ||
             booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
     val canDownloadContract = booking.statusAllowsContractDownload()
+    val canSignContract = booking.canShowSignContractAsOwner()
 
     Column(
         gap = 16.px,
@@ -201,25 +205,47 @@ private fun DealItemCard(
             }
         }
 
-        if (canDownloadContract) {
+        if (canDownloadContract || canSignContract) {
             Row(
                 gap = 8.px,
                 modifier = { width(100.percent) },
             ) {
-                Button({
-                    style {
-                        padding(8.px, 16.px)
-                        backgroundColor(CSSColors.Blue)
-                        color(CSSColors.White)
-                        border(0.px)
-                        borderRadius(8.px)
-                        fontSize(14.px)
-                        fontWeight("600")
-                        cursor("pointer")
+                if (canDownloadContract) {
+                    Button({
+                        style {
+                            padding(8.px, 16.px)
+                            backgroundColor(CSSColors.Blue)
+                            color(CSSColors.White)
+                            border(0.px)
+                            borderRadius(8.px)
+                            fontSize(14.px)
+                            fontWeight("600")
+                            cursor("pointer")
+                        }
+                        onClick { onDownloadContract() }
+                    }) {
+                        Text("Договор")
                     }
-                    onClick { onDownloadContract() }
-                }) {
-                    Text("Договор")
+                }
+                if (canSignContract) {
+                    Button({
+                        style {
+                            padding(8.px, 16.px)
+                            backgroundColor(CSSColors.Blue)
+                            color(CSSColors.White)
+                            border(0.px)
+                            borderRadius(8.px)
+                            fontSize(14.px)
+                            fontWeight("600")
+                            cursor(if (isActionInProgress) "default" else "pointer")
+                            property("opacity", if (isActionInProgress) "0.6" else "1")
+                        }
+                        if (!isActionInProgress) {
+                            onClick { onSignContract() }
+                        }
+                    }) {
+                        Text(if (isActionInProgress) "Подписание..." else "Подписать договор")
+                    }
                 }
             }
         }

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/chat/ChatScreen.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/chat/ChatScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.delay
 import my.drivebit.mobile.screens.main.LeaveReviewScreen
 import my.drivebit.network.services.BookingDTO
 import my.drivebit.network.services.MessageDto
+import my.drivebit.network.services.canShowSignContractInChat
 import my.drivebit.network.services.contractBookingIdForAction
 import my.drivebit.network.services.contractDownloadPageUrl
 import my.drivebit.network.services.isLeaveReviewForCarAction
@@ -71,6 +72,7 @@ data class ChatScreen(
         val isLoading by viewModel.isLoading.collectAsState()
         val error by viewModel.error.collectAsState()
         val isPaying by viewModel.isPaying.collectAsState()
+        val signActionInProgress by viewModel.signActionInProgress.collectAsState()
         val bookingPaymentById by viewModel.bookingPaymentById.collectAsState()
         var messageText by remember { mutableStateOf("") }
         var payInfo by remember { mutableStateOf<String?>(null) }
@@ -146,6 +148,7 @@ data class ChatScreen(
                                     bookingForPay = bookingIdForPay?.let { bookingPaymentById[it] },
                                     bookingById = bookingPaymentById,
                                     isPaying = isPaying,
+                                    signActionInProgress = signActionInProgress,
                                     onPrepayBooking = { bookingId ->
                                         viewModel.prepayBooking(
                                             bookingId = bookingId,
@@ -165,6 +168,12 @@ data class ChatScreen(
                                     },
                                     onLeaveReviewForRenter = {
                                         uriHandler.openUri("https://drivebit.ru/my-deals")
+                                    },
+                                    onSignContract = { bookingId, counterpartyUserId ->
+                                        viewModel.signContract(
+                                            bookingId = bookingId,
+                                            counterpartyUserId = counterpartyUserId,
+                                        )
                                     },
                                 )
                             }
@@ -216,10 +225,12 @@ private fun MessageBubble(
     bookingForPay: BookingDTO? = null,
     bookingById: Map<String, BookingDTO> = emptyMap(),
     isPaying: Boolean = false,
+    signActionInProgress: Set<String> = emptySet(),
     onPrepayBooking: (String) -> Unit = {},
     onPayBooking: (String) -> Unit = {},
     onLeaveReviewForCar: (String) -> Unit = {},
     onLeaveReviewForRenter: () -> Unit = {},
+    onSignContract: (bookingId: String, counterpartyUserId: String) -> Unit = { _, _ -> },
 ) {
     val senderId = message.sender?.id
     val isOwnMessage = participantId != null && senderId != null && senderId != participantId
@@ -253,6 +264,12 @@ private fun MessageBubble(
             val reviewCarId = message.leaveReviewCarIdForAction(bookingById)
             val showReviewForCar = message.isLeaveReviewForCarAction()
             val showReviewForRenter = message.shouldShowLeaveReviewForRenter()
+            val bookingForContract = bookingIdForContract?.let { bookingById[it] }
+            val showSignContract =
+                bookingIdForContract != null &&
+                    participantId != null &&
+                    bookingForContract?.canShowSignContractInChat(participantId) == true
+            val isSigningContract = bookingIdForContract != null && bookingIdForContract in signActionInProgress
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -291,6 +308,15 @@ private fun MessageBubble(
                         modifier = Modifier.padding(top = 8.dp),
                     ) {
                         Text("Скачать договор")
+                    }
+                }
+                if (showSignContract) {
+                    Button(
+                        onClick = { onSignContract(bookingIdForContract!!, participantId!!) },
+                        enabled = !isSigningContract,
+                        modifier = Modifier.padding(top = 8.dp),
+                    ) {
+                        Text(if (isSigningContract) "Подписание..." else "Подписать договор")
                     }
                 }
                 if (showReviewForCar) {

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/InboxTab.kt
@@ -28,6 +28,7 @@ import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
 import kotlinx.coroutines.delay
 import my.drivebit.network.services.BookingDTO
+import my.drivebit.network.services.canShowSignContractAsOwner
 import my.drivebit.ui.icons.Icons
 import my.drivebit.ui.theme.DrivebitTheme
 import my.drivebit.viewmodels.MyBookingsAsOwnerViewModel
@@ -107,6 +108,7 @@ object InboxTab : Tab {
                                 isActionInProgress = booking.id in actionInProgress,
                                 onConfirm = { viewModel.confirmBooking(booking.id) },
                                 onDecline = { viewModel.declineBooking(booking.id) },
+                                onSignContract = { viewModel.signContractAsOwner(booking.id) },
                             )
                         }
                     }
@@ -122,6 +124,7 @@ internal fun DealItemCard(
     isActionInProgress: Boolean,
     onConfirm: () -> Unit,
     onDecline: () -> Unit,
+    onSignContract: () -> Unit = {},
 ) {
     val renterName = booking.renterName?.takeIf { it.isNotBlank() } ?: "Арендатор"
     val carName =
@@ -133,6 +136,7 @@ internal fun DealItemCard(
     val canConfirmOrDecline =
         booking.status.equals("Pending", ignoreCase = true) ||
             booking.status.equals("AwaitingOwnerConfirmation", ignoreCase = true)
+    val canSignContract = booking.canShowSignContractAsOwner()
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -166,6 +170,16 @@ internal fun DealItemCard(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (canSignContract) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onSignContract,
+                    enabled = !isActionInProgress,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(if (isActionInProgress) "Подписание..." else "Подписать договор")
+                }
+            }
             if (canConfirmOrDecline) {
                 Spacer(modifier = Modifier.height(12.dp))
                 if (isActionInProgress) {

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/TripsTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/TripsTab.kt
@@ -34,6 +34,7 @@ import cafe.adriel.voyager.navigator.tab.TabOptions
 import kotlinx.coroutines.delay
 import my.drivebit.mobile.screens.main.LeaveReviewScreen
 import my.drivebit.network.services.BookingDTO
+import my.drivebit.network.services.canShowSignContractAsRenter
 import my.drivebit.network.services.contractDownloadPageUrl
 import my.drivebit.network.services.prepaymentButtonLabel
 import my.drivebit.network.services.renterFullOrBalanceAmountRub
@@ -69,6 +70,7 @@ object TripsTab : Tab {
         val isLoading by viewModel.isLoading.collectAsState()
         val error by viewModel.error.collectAsState()
         val isPaying by viewModel.isPaying.collectAsState()
+        val actionInProgress by viewModel.actionInProgress.collectAsState()
         val uriHandler = LocalUriHandler.current
         var payInfo by remember { mutableStateOf<String?>(null) }
 
@@ -146,6 +148,7 @@ object TripsTab : Tab {
                             BookingItemCard(
                                 booking = booking,
                                 isPaying = isPaying,
+                                isActionInProgress = booking.id in actionInProgress,
                                 onLeaveReview = {
                                     navigator.push(LeaveReviewScreen(carId = booking.carId))
                                 },
@@ -163,6 +166,7 @@ object TripsTab : Tab {
                                         failUrl = MOBILE_PAYMENT_FAIL_URL,
                                     )
                                 },
+                                onSignContract = { viewModel.signContractAsRenter(booking.id) },
                                 onDownloadContract = {
                                     uriHandler.openUri(contractDownloadPageUrl(booking.id))
                                 },
@@ -179,9 +183,11 @@ object TripsTab : Tab {
 internal fun BookingItemCard(
     booking: BookingDTO,
     isPaying: Boolean = false,
+    isActionInProgress: Boolean = false,
     onLeaveReview: () -> Unit,
     onPay: () -> Unit = {},
     onPrepay: () -> Unit = {},
+    onSignContract: () -> Unit = {},
     onDownloadContract: () -> Unit = {},
 ) {
     val carName =
@@ -193,9 +199,10 @@ internal fun BookingItemCard(
     val canLeaveReview = booking.status.equals("Completed", ignoreCase = true)
     val canPay = booking.statusAllowsRenterPayment()
     val canDownloadContract = booking.statusAllowsContractDownload()
+    val canSignContract = booking.canShowSignContractAsRenter()
     val fullPaymentLabel =
         "${booking.renterFullOrBalancePaymentLabel()} (${booking.renterFullOrBalanceAmountRub()} ₽)"
-    val showActions = canPay || booking.canPayPrepayment || canLeaveReview || canDownloadContract
+    val showActions = canPay || booking.canPayPrepayment || canLeaveReview || canDownloadContract || canSignContract
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -252,6 +259,16 @@ internal fun BookingItemCard(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text("Договор")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                if (canSignContract) {
+                    Button(
+                        onClick = onSignContract,
+                        enabled = !isActionInProgress,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(if (isActionInProgress) "Подписание..." else "Подписать договор")
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                 }

--- a/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/TripsTab.kt
+++ b/Mobile/src/commonMain/kotlin/my/drivebit/mobile/screens/main/tabs/TripsTab.kt
@@ -93,6 +93,10 @@ object TripsTab : Tab {
 
         LaunchedEffect(Unit) {
             viewModel.loadBookings()
+            while (true) {
+                delay(30_000)
+                viewModel.refreshBookings()
+            }
         }
 
         Column(

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -19,6 +19,7 @@ import my.drivebit.network.collectErrorMessages
 import my.drivebit.network.consumeResponse
 import my.drivebit.network.defaultJson
 import my.drivebit.network.parseResponse
+import my.drivebit.utils.resolveMinioImageUrlForBrowser
 
 interface Booking {
     suspend fun calculate(request: CheckBookingAvailabilityRequest): CheckBookingAvailabilityResponse
@@ -34,6 +35,10 @@ interface Booking {
     suspend fun confirmAsOwner(bookingId: String)
 
     suspend fun declineAsOwner(bookingId: String)
+
+    suspend fun signContractAsOwner(bookingId: String): BookingDTO
+
+    suspend fun signContractAsRenter(bookingId: String): BookingDTO
 
     suspend fun getContract(bookingId: String): GetBookingContractResult
 }
@@ -99,6 +104,13 @@ data class BookingDTO(
     @JsonNames("prepaymentPaidAt", "prepayment_paid_at") val prepaymentPaidAt: String? = null,
     @JsonNames("prepaymentAvailable", "prepayment_available") val prepaymentAvailable: Boolean = false,
     @JsonNames("canPayPrepayment", "can_pay_prepayment") val canPayPrepayment: Boolean = false,
+    @JsonNames("canPayFullAmount", "can_pay_full_amount") val canPayFullAmount: Boolean = false,
+    @JsonNames("contractSignedByOwner", "contract_signed_by_owner") val contractSignedByOwner: Boolean = false,
+    @JsonNames("contractSignedByRenter", "contract_signed_by_renter") val contractSignedByRenter: Boolean = false,
+    @JsonNames("canSignContractAsOwner", "can_sign_contract_as_owner") val canSignContractAsOwner: Boolean = false,
+    @JsonNames("canSignContractAsRenter", "can_sign_contract_as_renter") val canSignContractAsRenter: Boolean = false,
+    @JsonNames("contractSignedByOwnerAt", "contract_signed_by_owner_at") val contractSignedByOwnerAt: String? = null,
+    @JsonNames("contractSignedByRenterAt", "contract_signed_by_renter_at") val contractSignedByRenterAt: String? = null,
     @JsonNames("dailyRate", "daily_rate") val dailyRate: Double = 0.0,
     val status: String,
     val statusTranslate: String? = null,
@@ -111,7 +123,7 @@ enum class BookingCheckoutKind {
     FullOrBalance,
 }
 
-fun BookingDTO.statusAllowsRenterPayment(): Boolean = status.equals("Confirmed", ignoreCase = true)
+fun BookingDTO.statusAllowsRenterPayment(): Boolean = canPayFullAmount
 
 fun BookingDTO.renterFullOrBalanceAmountRub(): Int {
     val amount =
@@ -162,11 +174,51 @@ data class BookingContractDownloadDto(
     @JsonNames("generatedAt", "generated_at") val generatedAt: String,
 )
 
+fun BookingContractDownloadDto.browserDownloadUrl(): String = resolveMinioImageUrlForBrowser(downloadUrl) ?: downloadUrl
+
 fun BookingDTO.statusAllowsContractDownload(): Boolean =
     status.equals("Confirmed", ignoreCase = true) ||
+        status.equals("PrePaid", ignoreCase = true) ||
         status.equals("Paid", ignoreCase = true) ||
+        status.equals("ContractSignedByOwner", ignoreCase = true) ||
+        status.equals("ContractSignedByRenter", ignoreCase = true) ||
+        status.equals("ContractSignedByBoth", ignoreCase = true) ||
         status.equals("Active", ignoreCase = true) ||
         status.equals("Completed", ignoreCase = true)
+
+fun BookingDTO.canShowSignContractAsOwner(): Boolean =
+    canSignContractAsOwner ||
+        (statusAllowsContractSignUi() && !contractSignedByOwner)
+
+fun BookingDTO.canShowSignContractAsRenter(): Boolean =
+    canSignContractAsRenter ||
+        (statusAllowsContractSignUi() && !contractSignedByRenter)
+
+private fun BookingDTO.statusAllowsContractSignUi(): Boolean =
+    status.equals("Confirmed", ignoreCase = true) ||
+        status.equals("PrePaid", ignoreCase = true) ||
+        status.equals("Paid", ignoreCase = true) ||
+        status.equals("ContractSignedByOwner", ignoreCase = true) ||
+        status.equals("ContractSignedByRenter", ignoreCase = true)
+
+fun BookingDTO.canShowSignContractInChat(counterpartyUserId: String): Boolean =
+    when (counterpartyUserId) {
+        ownerId -> canShowSignContractAsRenter()
+        renterId -> canShowSignContractAsOwner()
+        else -> false
+    }
+
+enum class SignContractChatRole {
+    Owner,
+    Renter,
+}
+
+fun BookingDTO.signContractChatRole(counterpartyUserId: String): SignContractChatRole? =
+    when (counterpartyUserId) {
+        ownerId -> if (canShowSignContractAsRenter()) SignContractChatRole.Renter else null
+        renterId -> if (canShowSignContractAsOwner()) SignContractChatRole.Owner else null
+        else -> null
+    }
 
 fun BookingDTO.isTerminalRenterBooking(): Boolean =
     status.equals("Completed", ignoreCase = true) ||
@@ -226,6 +278,18 @@ class BookingImpl(
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/decline"
         val response = authorizedHttpClient.put(url) { }
         response.consumeResponse()
+    }
+
+    override suspend fun signContractAsOwner(bookingId: String): BookingDTO {
+        val url = "${DEFAULT_BASE_URL}Booking/$bookingId/sign-contract-as-owner"
+        val response = authorizedHttpClient.post(url) { }
+        return response.parseResponse()
+    }
+
+    override suspend fun signContractAsRenter(bookingId: String): BookingDTO {
+        val url = "${DEFAULT_BASE_URL}Booking/$bookingId/sign-contract-as-renter"
+        val response = authorizedHttpClient.post(url) { }
+        return response.parseResponse()
     }
 
     override suspend fun getContract(bookingId: String): GetBookingContractResult {

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Chat.kt
@@ -30,6 +30,7 @@ enum class ActionTypeEnum {
     LeaveReviewForCar,
     ConfirmBooking,
     DownloadContract,
+    SignContract,
 }
 
 object ActionTypeEnumSerializer : KSerializer<ActionTypeEnum> {
@@ -262,7 +263,9 @@ fun MessageDto.contractBookingIdForAction(): String? {
         messageActionBlock?.actionParameters?.get("bookingId")?.takeIf { it.isNotBlank() }
             ?: bookingId?.takeIf { it.isNotBlank() }
     when (messageActionBlock?.actionType) {
-        ActionTypeEnum.DownloadContract -> return bookingFromMessage
+        ActionTypeEnum.DownloadContract,
+        ActionTypeEnum.SignContract,
+        -> return bookingFromMessage
         else -> {}
     }
     return text?.let(::extractBookingIdFromContractDownloadUrl)

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingContractDownloadDtoTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingContractDownloadDtoTest.kt
@@ -97,4 +97,37 @@ class BookingContractDownloadDtoTest {
             assertEquals(1L, result.contractNumber)
             assertEquals("https://x", result.downloadUrl)
         }
+
+    @Test
+    fun `browserDownloadUrl rewrites direct MinIO presigned URL to same-origin path`() {
+        val dto =
+            BookingContractDownloadDto(
+                contractNumber = 1L,
+                fileName = "dogovor.pdf",
+                downloadUrl =
+                    "http://157.22.252.70:9000/privatebct/contracts/booking/file.pdf" +
+                        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc",
+                urlExpiresAt = "2026-01-01T00:00:00Z",
+                generatedAt = "2026-01-01T00:00:00Z",
+            )
+
+        assertEquals(
+            "/privatebct/contracts/booking/file.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc",
+            dto.browserDownloadUrl(),
+        )
+    }
+
+    @Test
+    fun `browserDownloadUrl leaves already proxied URLs unchanged`() {
+        val dto =
+            BookingContractDownloadDto(
+                contractNumber = 1L,
+                fileName = "dogovor.pdf",
+                downloadUrl = "https://drivebit.ru/privatebct/contracts/file.pdf?sig=1",
+                urlExpiresAt = "2026-01-01T00:00:00Z",
+                generatedAt = "2026-01-01T00:00:00Z",
+            )
+
+        assertEquals(dto.downloadUrl, dto.browserDownloadUrl())
+    }
 }

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingPrepaymentTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingPrepaymentTest.kt
@@ -61,9 +61,76 @@ class BookingPrepaymentTest {
     }
 
     @Test
-    fun statusAllowsRenterPayment_onlyForConfirmed() {
-        assertTrue(booking(status = "Confirmed").statusAllowsRenterPayment())
-        assertFalse(booking(status = "Paid").statusAllowsRenterPayment())
+    fun statusAllowsRenterPayment_usesCanPayFullAmountFromApi() {
+        assertTrue(
+            booking(
+                status = "Confirmed",
+                canPayFullAmount = true,
+            ).statusAllowsRenterPayment(),
+        )
+        assertTrue(
+            booking(
+                status = "PrePaid",
+                canPayFullAmount = true,
+            ).statusAllowsRenterPayment(),
+        )
+        assertFalse(
+            booking(
+                status = "Paid",
+                canPayFullAmount = false,
+            ).statusAllowsRenterPayment(),
+        )
+    }
+
+    @Test
+    fun statusAllowsContractDownload_includesContractSignatureStatuses() {
+        assertTrue(booking(status = "Confirmed").statusAllowsContractDownload())
+        assertTrue(booking(status = "PrePaid").statusAllowsContractDownload())
+        assertTrue(booking(status = "ContractSignedByOwner").statusAllowsContractDownload())
+        assertTrue(booking(status = "ContractSignedByBoth").statusAllowsContractDownload())
+        assertFalse(booking(status = "Pending").statusAllowsContractDownload())
+    }
+
+    @Test
+    fun canShowSignContract_visibleAfterConfirmedEvenWhenApiFlagFalse() {
+        val ownerView =
+            booking(
+                status = "Confirmed",
+                canSignContractAsOwner = false,
+                contractSignedByOwner = false,
+            )
+        val renterView =
+            booking(
+                status = "Confirmed",
+                canSignContractAsRenter = false,
+                contractSignedByRenter = false,
+            )
+
+        assertTrue(ownerView.canShowSignContractAsOwner())
+        assertTrue(renterView.canShowSignContractAsRenter())
+    }
+
+    @Test
+    fun canShowSignContract_hiddenAfterPartySigned() {
+        val booking =
+            booking(
+                status = "Confirmed",
+                contractSignedByOwner = true,
+            )
+
+        assertFalse(booking.canShowSignContractAsOwner())
+    }
+
+    @Test
+    fun canShowSignContract_stillUsesApiFlagWhenPaid() {
+        val booking =
+            booking(
+                status = "Paid",
+                canSignContractAsOwner = true,
+                contractSignedByOwner = false,
+            )
+
+        assertTrue(booking.canShowSignContractAsOwner())
     }
 
     private fun booking(
@@ -72,6 +139,11 @@ class BookingPrepaymentTest {
         prepaymentPercent: Double = 0.0,
         prepaymentAmount: Double = 0.0,
         canPayPrepayment: Boolean = false,
+        canPayFullAmount: Boolean = false,
+        canSignContractAsOwner: Boolean = false,
+        canSignContractAsRenter: Boolean = false,
+        contractSignedByOwner: Boolean = false,
+        contractSignedByRenter: Boolean = false,
         totalAmountWithDeposit: Double = 0.0,
         balanceDueAmount: Double = 0.0,
     ): BookingDTO =
@@ -90,6 +162,11 @@ class BookingPrepaymentTest {
             balanceDueAmount = balanceDueAmount,
             prepaymentPaidAt = prepaymentPaidAt,
             canPayPrepayment = canPayPrepayment,
+            canPayFullAmount = canPayFullAmount,
+            canSignContractAsOwner = canSignContractAsOwner,
+            canSignContractAsRenter = canSignContractAsRenter,
+            contractSignedByOwner = contractSignedByOwner,
+            contractSignedByRenter = contractSignedByRenter,
             status = status,
             createdAt = "2026-05-27T10:00:00Z",
         )

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingSignContractTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingSignContractTest.kt
@@ -1,0 +1,93 @@
+package my.drivebit.network.services
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BookingSignContractTest {
+    @Test
+    fun `signContractAsOwner posts to owner endpoint and parses response`() =
+        runTest {
+            val bookingId = "550e8400-e29b-41d4-a716-446655440000"
+            var requestedPath: String? = null
+            val mockEngine =
+                MockEngine { request ->
+                    requestedPath = request.url.encodedPath
+                    assertEquals(HttpMethod.Post, request.method)
+                    respond(
+                        content =
+                            """
+                            {
+                              "id": "$bookingId",
+                              "carId": "660e8400-e29b-41d4-a716-446655440001",
+                              "renterId": "770e8400-e29b-41d4-a716-446655440002",
+                              "ownerId": "880e8400-e29b-41d4-a716-446655440003",
+                              "startAt": "2026-05-28T10:00:00Z",
+                              "endAt": "2026-05-30T10:00:00Z",
+                              "totalAmount": 10000.0,
+                              "status": "ContractSignedByOwner",
+                              "canSignContractAsOwner": false,
+                              "canSignContractAsRenter": true,
+                              "contractSignedByOwner": true,
+                              "createdAt": "2026-05-27T10:00:00Z"
+                            }
+                            """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val booking = BookingImpl(HttpClient(mockEngine), HttpClient(mockEngine))
+            val result = booking.signContractAsOwner(bookingId)
+
+            assertTrue(requestedPath!!.endsWith("/Booking/$bookingId/sign-contract-as-owner"))
+            assertEquals("ContractSignedByOwner", result.status)
+            assertTrue(result.contractSignedByOwner)
+            assertTrue(result.canSignContractAsRenter)
+        }
+
+    @Test
+    fun `signContractAsRenter posts to renter endpoint and parses response`() =
+        runTest {
+            val bookingId = "550e8400-e29b-41d4-a716-446655440000"
+            var requestedPath: String? = null
+            val mockEngine =
+                MockEngine { request ->
+                    requestedPath = request.url.encodedPath
+                    assertEquals(HttpMethod.Post, request.method)
+                    respond(
+                        content =
+                            """
+                            {
+                              "id": "$bookingId",
+                              "carId": "660e8400-e29b-41d4-a716-446655440001",
+                              "renterId": "770e8400-e29b-41d4-a716-446655440002",
+                              "ownerId": "880e8400-e29b-41d4-a716-446655440003",
+                              "startAt": "2026-05-28T10:00:00Z",
+                              "endAt": "2026-05-30T10:00:00Z",
+                              "totalAmount": 10000.0,
+                              "status": "ContractSignedByRenter",
+                              "canSignContractAsRenter": false,
+                              "contractSignedByRenter": true,
+                              "createdAt": "2026-05-27T10:00:00Z"
+                            }
+                            """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val booking = BookingImpl(HttpClient(mockEngine), HttpClient(mockEngine))
+            val result = booking.signContractAsRenter(bookingId)
+
+            assertTrue(requestedPath!!.endsWith("/Booking/$bookingId/sign-contract-as-renter"))
+            assertEquals("ContractSignedByRenter", result.status)
+            assertTrue(result.contractSignedByRenter)
+        }
+}

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/ChatContractActionTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/ChatContractActionTest.kt
@@ -1,0 +1,208 @@
+package my.drivebit.network.services
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ChatContractActionTest {
+    @Test
+    fun contractBookingIdForAction_returnsBookingIdForDownloadContractAction() {
+        val message =
+            MessageDto(
+                id = "1",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                messageActionBlock =
+                    MessageActionBlockDto(
+                        actionType = ActionTypeEnum.DownloadContract,
+                        actionParameters = mapOf("bookingId" to "550e8400-e29b-41d4-a716-446655440000"),
+                    ),
+            )
+
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", message.contractBookingIdForAction())
+    }
+
+    @Test
+    fun contractBookingIdForAction_parsesUrlFromTextWhenActionBlockMissing() {
+        val message =
+            MessageDto(
+                id = "2",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                text =
+                    "Бронирование подтверждено.\n\n" +
+                        "Скачать договор аренды: https://drivebit.ru/download-booking-contract?bookingId=660e8400-e29b-41d4-a716-446655440001",
+            )
+
+        assertEquals("660e8400-e29b-41d4-a716-446655440001", message.contractBookingIdForAction())
+    }
+
+    @Test
+    fun contractBookingIdForAction_returnsNullForRegularMessage() {
+        val message =
+            MessageDto(
+                id = "3",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                text = "Привет",
+            )
+
+        assertNull(message.contractBookingIdForAction())
+    }
+
+    @Test
+    fun payBookingIdForAction_doesNotReturnForDownloadContract() {
+        val message =
+            MessageDto(
+                id = "4",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                messageActionBlock =
+                    MessageActionBlockDto(
+                        actionType = ActionTypeEnum.DownloadContract,
+                        actionParameters = mapOf("bookingId" to "550e8400-e29b-41d4-a716-446655440000"),
+                    ),
+            )
+
+        assertNull(message.payBookingIdForAction())
+    }
+
+    @Test
+    fun leaveReviewCarIdForAction_returnsCarIdFromParameters() {
+        val message =
+            MessageDto(
+                id = "5",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                messageActionBlock =
+                    MessageActionBlockDto(
+                        actionType = ActionTypeEnum.LeaveReviewForCar,
+                        actionParameters = mapOf("carId" to "car-123"),
+                    ),
+            )
+
+        assertEquals("car-123", message.leaveReviewCarIdForAction())
+    }
+
+    @Test
+    fun leaveReviewCarIdForAction_resolvesCarIdFromBookingLookup() {
+        val message =
+            MessageDto(
+                id = "6",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                messageActionBlock =
+                    MessageActionBlockDto(
+                        actionType = ActionTypeEnum.LeaveReviewForCar,
+                        actionParameters = mapOf("bookingId" to "booking-1"),
+                    ),
+            )
+        val booking =
+            BookingDTO(
+                id = "booking-1",
+                carId = "car-from-booking",
+                renterId = "r1",
+                ownerId = "o1",
+                startAt = "2026-05-20T10:00:00Z",
+                endAt = "2026-05-22T10:00:00Z",
+                totalAmount = 1000.0,
+                status = "Completed",
+                createdAt = "2026-05-19T10:00:00Z",
+            )
+
+        assertEquals(
+            "car-from-booking",
+            message.leaveReviewCarIdForAction(mapOf("booking-1" to booking)),
+        )
+    }
+
+    @Test
+    fun leaveReviewCarIdForAction_usesBookingCompletedRenterTextFallback() {
+        val message =
+            MessageDto(
+                id = "7",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                systemMessageType = SystemMessageType.BookingCompleted,
+                bookingId = "booking-2",
+                text = "Ваша аренда автомобиля Toyota завершена. Вы можете оставить отзыв об аренде.",
+            )
+        val booking =
+            BookingDTO(
+                id = "booking-2",
+                carId = "car-2",
+                renterId = "r1",
+                ownerId = "o1",
+                startAt = "2026-05-20T10:00:00Z",
+                endAt = "2026-05-22T10:00:00Z",
+                totalAmount = 1000.0,
+                status = "Completed",
+                createdAt = "2026-05-19T10:00:00Z",
+            )
+
+        assertTrue(message.isLeaveReviewForCarAction())
+        assertEquals("car-2", message.leaveReviewCarIdForAction(mapOf("booking-2" to booking)))
+    }
+
+    @Test
+    fun shouldShowLeaveReviewForRenter_forOwnerBookingCompletedText() {
+        val message =
+            MessageDto(
+                id = "8",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                systemMessageType = SystemMessageType.BookingCompleted,
+                text = "Аренда завершена. Вы можете оставить отзыв об арендаторе.",
+            )
+
+        assertTrue(message.shouldShowLeaveReviewForRenter())
+        assertFalse(message.isLeaveReviewForCarAction())
+    }
+
+    @Test
+    fun contractBookingIdForAction_returnsBookingIdForSignContractAction() {
+        val message =
+            MessageDto(
+                id = "9",
+                chatId = "c1",
+                createdAt = "2026-05-28T12:00:00Z",
+                isSystemMessage = true,
+                messageActionBlock =
+                    MessageActionBlockDto(
+                        actionType = ActionTypeEnum.SignContract,
+                        actionParameters = mapOf("bookingId" to "770e8400-e29b-41d4-a716-446655440002"),
+                    ),
+            )
+
+        assertEquals("770e8400-e29b-41d4-a716-446655440002", message.contractBookingIdForAction())
+    }
+
+    @Test
+    fun canShowSignContractInChat_usesCounterpartyToDetectRole() {
+        val booking =
+            BookingDTO(
+                id = "booking-1",
+                carId = "car-1",
+                renterId = "renter-1",
+                ownerId = "owner-1",
+                startAt = "2026-05-20T10:00:00Z",
+                endAt = "2026-05-22T10:00:00Z",
+                totalAmount = 1000.0,
+                status = "Confirmed",
+                createdAt = "2026-05-19T10:00:00Z",
+            )
+
+        assertTrue(booking.canShowSignContractInChat(counterpartyUserId = "owner-1"))
+        assertTrue(booking.canShowSignContractInChat(counterpartyUserId = "renter-1"))
+        assertFalse(booking.canShowSignContractInChat(counterpartyUserId = "stranger"))
+    }
+}


### PR DESCRIPTION
## Summary

- Fix contract download on HTTPS production: rewrite MinIO presigned `http://157.22.252.70:9000/privatebct/...` URLs to same-origin `/privatebct/...` before opening in the browser (avoids mixed-content blocking).
- Add contract signing UI across bookings and chat.
- Poll renter bookings every 30s on web (`/my-bookings/`) and mobile Trips tab.

## Root cause (prod download)

Backend returns presigned MinIO URLs over HTTP. On `https://drivebit.ru` the browser blocks direct navigation to `http://157.22.252.70:9000/...` as mixed content. Rewriting to `/privatebct/...` works through existing nginx proxy (verified: GET returns 200).

## Test plan

- [ ] Open `/download-booking-contract?bookingId=...` on staging/prod after deploy; click «Скачать договор» — PDF downloads via HTTPS
- [ ] Sign contract buttons visible after Confirmed on my-deals / my-bookings / chat
- [ ] Renter bookings list refreshes without manual reload