### PR TITLE
fix(utils): correct availability block date display and disabled dates

### DIFF
--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/AvailabilityBlockDates.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/AvailabilityBlockDates.kt
@@ -2,10 +2,13 @@
 
 package my.drivebit.utils
 
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 
 data class AvailabilityBlockInterval(
     val startAt: String,
@@ -31,19 +34,43 @@ fun availabilityBlockIntervalFromDates(
     return AvailabilityBlockInterval(startAt = startAt, endAt = endAt)
 }
 
+fun availabilityBlockStartLocalDate(
+    startAt: String,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): LocalDate {
+    val local = Instant.parse(startAt).toLocalDateTime(timeZone)
+    return LocalDate(local.year, local.month, local.day)
+}
+
+fun availabilityBlockLastLocalDate(
+    endAt: String,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): LocalDate {
+    val local = Instant.parse(endAt).toLocalDateTime(timeZone)
+    val date = LocalDate(local.year, local.month, local.day)
+    return if (local.hour == 0 && local.minute == 0 && local.second == 0 && local.nanosecond == 0) {
+        addDays(date, -1)
+    } else {
+        date
+    }
+}
+
+fun formatLocalDate(date: LocalDate): String {
+    val day = date.day.toString().padStart(2, '0')
+    val month =
+        date.month.number
+            .toString()
+            .padStart(2, '0')
+    val year = date.year
+    return "$day.$month.$year"
+}
+
 fun formatAvailabilityBlockPeriod(
     startAt: String,
     endAt: String,
     timeZone: TimeZone = TimeZone.currentSystemDefault(),
 ): String {
-    val startDisplay = mapIso8601ToDateString(startAt)
-    val endExclusive = LocalDate.parse(endAt.take(10))
-    val lastBlockedDay = addDays(endExclusive, -1)
-    val endDisplay =
-        mapIso8601ToDateString(
-            LocalDateTime(lastBlockedDay.year, lastBlockedDay.month, lastBlockedDay.day, 0, 0, 0, 0)
-                .toInstant(timeZone)
-                .toString(),
-        )
+    val startDisplay = formatLocalDate(availabilityBlockStartLocalDate(startAt, timeZone))
+    val endDisplay = formatLocalDate(availabilityBlockLastLocalDate(endAt, timeZone))
     return if (startDisplay == endDisplay) startDisplay else "$startDisplay — $endDisplay"
 }

--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/BookingIntervalCalendarDates.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/BookingIntervalCalendarDates.kt
@@ -1,16 +1,16 @@
 package my.drivebit.utils
 
-import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
 
-fun parseDisabledDatesFromIsoIntervals(intervals: List<Pair<String, String>>): Set<String> {
+fun parseDisabledDatesFromIsoIntervals(
+    intervals: List<Pair<String, String>>,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+): Set<String> {
     val result = mutableSetOf<String>()
     for ((startRaw, endRaw) in intervals) {
-        val startStr = startRaw.take(10)
-        val endStr = endRaw.take(10)
-        if (startStr.length != 10 || endStr.length != 10) continue
         runCatching {
-            var d = LocalDate.parse(startStr)
-            val end = LocalDate.parse(endStr)
+            var d = availabilityBlockStartLocalDate(startRaw, timeZone)
+            val end = availabilityBlockLastLocalDate(endRaw, timeZone)
             while (d <= end) {
                 result.add(d.toString())
                 d = addDays(d, 1)

--- a/Utils/src/commonTest/kotlin/my/drivebit/utils/AvailabilityBlockDatesTest.kt
+++ b/Utils/src/commonTest/kotlin/my/drivebit/utils/AvailabilityBlockDatesTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AvailabilityBlockDatesTest {
+    private val utcPlus5 = TimeZone.of("+05:00")
+
     @Test
     fun `availabilityBlockIntervalFromDates should use start of day and exclusive end`() {
         val interval =
@@ -54,5 +56,103 @@ class AvailabilityBlockDatesTest {
             )
 
         assertEquals("10.06.2026 — 12.06.2026", period)
+    }
+
+    @Test
+    fun `formatAvailabilityBlockPeriod should show API inclusive end range`() {
+        val period =
+            formatAvailabilityBlockPeriod(
+                startAt = "2026-06-22T00:00:00.000Z",
+                endAt = "2026-06-23T23:59:59.000Z",
+                timeZone = TimeZone.UTC,
+            )
+
+        assertEquals("22.06.2026 — 23.06.2026", period)
+    }
+
+    @Test
+    fun `formatAvailabilityBlockPeriod should show API inclusive end range for 25-26`() {
+        val period =
+            formatAvailabilityBlockPeriod(
+                startAt = "2026-06-25T00:00:00.000Z",
+                endAt = "2026-06-26T23:59:59.000Z",
+                timeZone = TimeZone.UTC,
+            )
+
+        assertEquals("25.06.2026 — 26.06.2026", period)
+    }
+
+    @Test
+    fun `formatAvailabilityBlockPeriod should show single day for exclusive midnight UTC+5`() {
+        val period =
+            formatAvailabilityBlockPeriod(
+                startAt = "2026-06-19T19:00:00Z",
+                endAt = "2026-06-20T19:00:00Z",
+                timeZone = utcPlus5,
+            )
+
+        assertEquals("20.06.2026", period)
+    }
+
+    @Test
+    fun `formatAvailabilityBlockPeriod should show range for exclusive midnight UTC+5`() {
+        val period =
+            formatAvailabilityBlockPeriod(
+                startAt = "2026-06-10T19:00:00Z",
+                endAt = "2026-06-12T19:00:00Z",
+                timeZone = utcPlus5,
+            )
+
+        assertEquals("11.06.2026 — 12.06.2026", period)
+    }
+
+    @Test
+    fun `parseDisabledDatesFromIsoIntervals should match API inclusive end`() {
+        val disabled =
+            parseDisabledDatesFromIsoIntervals(
+                listOf("2026-06-22T00:00:00.000Z" to "2026-06-23T23:59:59.000Z"),
+                timeZone = TimeZone.UTC,
+            )
+
+        assertEquals(setOf("2026-06-22", "2026-06-23"), disabled)
+    }
+
+    @Test
+    fun `parseDisabledDatesFromIsoIntervals should match exclusive midnight UTC+5`() {
+        val disabled =
+            parseDisabledDatesFromIsoIntervals(
+                listOf("2026-06-10T19:00:00Z" to "2026-06-12T19:00:00Z"),
+                timeZone = utcPlus5,
+            )
+
+        assertEquals(setOf("2026-06-11", "2026-06-12"), disabled)
+    }
+
+    @Test
+    fun `parseDisabledDatesFromIsoIntervals should use exclusive end for midnight UTC`() {
+        val disabled =
+            parseDisabledDatesFromIsoIntervals(
+                listOf("2026-06-10T00:00:00Z" to "2026-06-12T00:00:00Z"),
+                timeZone = TimeZone.UTC,
+            )
+
+        assertEquals(setOf("2026-06-10", "2026-06-11"), disabled)
+    }
+
+    @Test
+    fun `availability block local dates should keep start before end`() {
+        val intervals =
+            listOf(
+                "2026-06-22T00:00:00.000Z" to "2026-06-23T23:59:59.000Z",
+                "2026-06-25T00:00:00.000Z" to "2026-06-26T23:59:59.000Z",
+                "2026-06-19T19:00:00Z" to "2026-06-20T19:00:00Z",
+                "2026-06-10T19:00:00Z" to "2026-06-12T19:00:00Z",
+            )
+        for ((startAt, endAt) in intervals) {
+            val timeZone = if (startAt.contains("19:00:00")) utcPlus5 else TimeZone.UTC
+            val start = availabilityBlockStartLocalDate(startAt, timeZone)
+            val end = availabilityBlockLastLocalDate(endAt, timeZone)
+            assertTrue(start <= end, "start $start should not be after end $end for $startAt / $endAt")
+        }
     }
 }


### PR DESCRIPTION
Normalize start/end parsing for both API inclusive and client exclusive end formats so blocked periods render in the right order and match the calendar.