### PR TITLE
fix(web): restore Yandex Metrika goals on auth and car-detail shells

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/analytics/YandexMetrica.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/analytics/YandexMetrica.kt
@@ -1,17 +1,34 @@
 package my.drivebit.analytics
 
+import kotlinx.browser.document
 import kotlinx.browser.window
+import org.w3c.dom.HTMLScriptElement
+import kotlin.js.js
 import kotlin.js.jsTypeOf
 
 private const val YANDEX_COUNTER_ID = 105947907
 private const val ARENDA_GOAL = "arenda"
 private const val BRON_GOAL = "bron"
+private const val DEFERRED_LOADER_PATH = "/vendor/drivebit-third-party-deferred.js"
+
+private fun ensureYandexMetrikaStub() {
+    val w = window.asDynamic()
+    if (jsTypeOf(w.ym) == "function") {
+        return
+    }
+    w.ym = js("function(){(window.ym.a=window.ym.a||[]).push(arguments)}")
+    if (document.querySelector("script[src*='drivebit-third-party-deferred']") != null) {
+        return
+    }
+    val script = document.createElement("script") as HTMLScriptElement
+    script.src = DEFERRED_LOADER_PATH
+    script.defer = true
+    document.head?.appendChild(script)
+}
 
 private fun reachYandexGoal(goal: String) {
-    val ym = window.asDynamic().ym
-    if (jsTypeOf(ym) == "function") {
-        ym(YANDEX_COUNTER_ID, "reachGoal", goal)
-    }
+    ensureYandexMetrikaStub()
+    window.asDynamic().ym(YANDEX_COUNTER_ID, "reachGoal", goal)
 }
 
 fun reachYandexGoalArenda() {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/LoginByPasswordPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/LoginByPasswordPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import kotlinx.browser.window
+import my.drivebit.analytics.reachYandexGoalArenda
 import my.drivebit.components.ActionButton
 import my.drivebit.components.ButtonContainer
 import my.drivebit.components.CenteredFormContainer
@@ -63,6 +64,7 @@ fun LoginByPasswordPage() {
 
     LaunchedEffect(uiState.authState) {
         if (uiState.authState is AuthFormState.Success) {
+            reachYandexGoalArenda()
             val targetPath =
                 when {
                     redirectPath.isNotBlank() -> redirectPath

--- a/authApp/src/jsMain/resources/auth-app-shell/index.html
+++ b/authApp/src/jsMain/resources/auth-app-shell/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-split-app-shell.css"/>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-split-app-shell">
     <!-- drivebit-app-header-start -->

--- a/carDetailApp/src/jsMain/resources/car-detail/index.html
+++ b/carDetailApp/src/jsMain/resources/car-detail/index.html
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-split-app-shell.css"/>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-split-app-shell">
 <!-- drivebit-app-header-start -->

--- a/vendor/drivebit-third-party-deferred.js
+++ b/vendor/drivebit-third-party-deferred.js
@@ -15,8 +15,20 @@
         }
     }
 
+    function isMetrikaTagRequested() {
+        for (var j = 0; j < document.scripts.length; j++) {
+            if (
+                document.scripts[j].src &&
+                document.scripts[j].src.indexOf("metrika/tag.js") !== -1
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     function loadMetrika() {
-        if (window.ym) {
+        if (isMetrikaTagRequested()) {
             return;
         }
         (function (m, e, t, r, i, k, a) {


### PR DESCRIPTION
## Summary
- Подключён `drivebit-third-party-deferred.js` в HTML-шеллы `authApp` и `carDetailApp`, где происходят вход/регистрация и бронирование.
- `YandexMetrica.kt` больше не молча теряет `reachGoal`, если `window.ym` ещё не инициализирован: создаётся stub и подгружается loader.
- Исправлен ранний выход в loader (проверка `tag.js`, а не наличие stub `window.ym`).
- Добавлен вызов цели `arenda` при успешном входе по паролю.

## Context
После split на отдельные бандлы (`authApp`, `carDetailApp`) на `/login-by-*`, `/verify-otp` и `/car-detail` не загружалась Метрика. Цели `arenda` и `bron` не срабатывали с ~3 июня (подтверждено MCP и проверкой prod: `window.ym === undefined`).

## Test plan
- [ ] Задеплоить и открыть `/car-detail` → в DevTools `typeof ym === "function"`, после клика «Забронировать» уходит `reachGoal('bron')`.
- [ ] Открыть `/login-by-phone` или `/verify-otp` → `typeof ym === "function"`, после входа/OTP уходит `reachGoal('arenda')`.
- [ ] Проверить вход по паролю → цель `arenda` на успешной авторизации.
- [ ] В Метрике (счётчик 105947907) появились достижения `arenda`/`bron` за текущий день.