### PR TITLE
Document SUV filter SEO landing page

### DIFF
--- a/composeApp/seo/README.md
+++ b/composeApp/seo/README.md
@@ -54,3 +54,29 @@ For bulk cars-grid skeleton rollout on listing pages, run `node scripts/inject-c
 
 1. Copy `moskva/kanikuly/index.html` (or closest filter).
 2. Update hero image preload, h1, filter `aria-pressed`, SEO block.
+
+## Body-type filter with custom SEO URL (example: Внедорожник)
+
+Use when the filter is **not** a trip-purpose slug (`kanikuly`, `pereezd`, …) but a long-tail URL from the SEO spec (e.g. `/moskva/arenda-vnedorozhnika-bez-voditelya`).
+
+### Checklist
+
+1. **Filter behavior** — `SuggestedFiltersCatalog.kt`: `shortName`, `bodyTypes` (e.g. `SUV`), icon.
+2. **Custom path segment** — `CityPathRouting.kt` → `CUSTOM_FILTER_PATH_SEGMENTS` (`"Внедорожник" to "arenda-vnedorozhnika-bez-voditelya"`).
+3. **Meta** — `landing-blocks.json` (`title`, `description`, `sections`), `MetaTags.kt`, `CityDeclensionUtils.kt`, `city-meta-bootstrap.js` (add slug to `SEO_OPTIMIZED_MOSKVA_FILTER_SLUGS` when using seo title suffix).
+4. **Static page** — `composeApp/src/jsMain/resources/moskva/{slug}/index.html` with unique `<title>`, description, canonical, H1, active filter button.
+5. **Full SEO text before footer** — put all sections in `landing-blocks.json`, then inject into `index.html`:
+   ```bash
+   python3 -c "
+   from pathlib import Path; import re
+   from scripts.seo_blocks import render_block
+   p = '/moskva/arenda-vnedorozhnika-bez-voditelya'
+   html = render_block(p)
+   f = Path('composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html')
+   f.write_text(re.sub(r'<div class=\"drivebit-seo-shell\">[\s\S]*?</div>\s*\n', html, f.read_text(encoding='utf-8'), count=1), encoding='utf-8')
+   "
+   ```
+6. **All filter rows** — replace button label/path in root `index.html`, every city page, `filters.fragment.html`.
+7. **Sitemap + deploy verify** — `sitemap.xml`, `.github/workflows/deploy.yml` slug list, `print-city-meta-table.mjs`.
+
+Full write-up: [docs/solutions/best-practices/seo-vnedorozhnik-filter-landing-page.md](../../docs/solutions/best-practices/seo-vnedorozhnik-filter-landing-page.md).

--- a/docs/solutions/best-practices/seo-vnedorozhnik-filter-landing-page.md
+++ b/docs/solutions/best-practices/seo-vnedorozhnik-filter-landing-page.md
@@ -1,0 +1,170 @@
+---
+title: SEO landing page for body-type filter (Внедорожник / SUV)
+date: 2026-07-02
+last_updated: 2026-07-02
+category: best-practices
+module: composeApp
+problem_type: best_practice
+component: seo
+severity: low
+applies_when:
+  - Adding a new Moscow filter button that filters by body type, not trip purpose
+  - Replacing an existing trip filter with a long-tail SEO URL (e.g. arenda-vnedorozhnika-bez-voditelya)
+  - Content spec lives in Google Doc + spreadsheet (title, description, H1, full SEO text)
+tags:
+  - seo
+  - vnedorozhnik
+  - suv
+  - landing-page
+  - filter-button
+  - moskva
+related_releases:
+  - v3.16.8
+  - v3.16.9
+related_prs:
+  - https://github.com/DriveBitCars/drivebit-clients/pull/254
+  - https://github.com/DriveBitCars/drivebit-clients/pull/255
+---
+
+# SEO landing page for body-type filter (Внедорожник / SUV)
+
+## Context
+
+Нужно было заменить кнопку фильтра **«Мероприятие»** на **«Внедорожник»** с фильтрацией по типу кузова `SUV`, выделить отдельный SEO-URL и положить в статический HTML полный текст из контент-спека (Google Doc + таблица SEO).
+
+Первая итерация (v3.16.8) добавила страницу и укороченный SEO-блок. Вторая (v3.16.9) дополнила полный текст перед футером — таблица премиум-класса, списки, все разделы из документа.
+
+**Целевой URL:** `https://drivebit.ru/moskva/arenda-vnedorozhnika-bez-voditelya`
+
+**Мета из спеки:**
+
+| Поле | Значение |
+|------|----------|
+| Title | Аренда внедорожника без водителя в Москве через сервис DriveBit |
+| Description | Аренда внедорожника без водителя в Москве через сервис DriveBit. Безопасно и быстро. Чистые и ухоженные автомобили дешевле каршеринга! |
+| H1 | Аренда внедорожника без водителя в Москве |
+
+## Guidance
+
+### 1. Фильтр по типу кузова (Kotlin)
+
+В `SuggestedFiltersCatalog.kt` заменить старый trip-filter на body-type filter:
+
+```kotlin
+FilterSuggestion(
+    name = "Внедорожник",
+    shortName = "Внедорожник",
+    iconUrl = "/images/filter-main/direction.svg",
+    bodyTypes = listOf(
+        EnumItem(number = 0, name = "SUV", translate = "Внедорожник"),
+    ),
+),
+```
+
+`CarSearchRepository` автоматически передаёт `bodyTypes = ["SUV"]` при `currentTaskShortName == "Внедорожник"`.
+
+### 2. Кастомный SEO-slug в URL
+
+Обычные фильтры slug'ятся через `cityNameToSlug` (`Путешествия` → `puteshestviya`). Для внедорожника нужен длинный slug из спеки.
+
+`DrivebitWeb/.../CityPathRouting.kt`:
+
+```kotlin
+private val CUSTOM_FILTER_PATH_SEGMENTS = mapOf(
+    "Внедорожник" to "arenda-vnedorozhnika-bez-voditelya",
+)
+```
+
+Обратное сопоставление — в `filterTitleFromPathSegment`.
+
+### 3. SEO meta (Kotlin + JS)
+
+- `Utils/.../CityDeclensionUtils.kt` — добавить `"Внедорожник"` в `seoPageHeadline`, slug в `SEO_OPTIMIZED_MOSKVA_FILTER_SLUGS`
+- `DrivebitWeb/.../MetaTags.kt` — явная запись для `/moskva/arenda-vnedorozhnika-bez-voditelya`
+- `vendor/city-meta-bootstrap.js` — зеркалить slug и headline для статических страниц
+
+### 4. Контент: `landing-blocks.json` + статический HTML
+
+**Источник правды для текста:** `composeApp/seo/landing-blocks.json` → ключ `/moskva/arenda-vnedorozhnika-bez-voditelya`.
+
+Структура с `sections` (как у `/moskva/puteshestviya`): заголовки, параграфы, `bullets`, `table`.
+
+Полный SEO-блок в `index.html` генерируется скриптом:
+
+```bash
+python3 -c "
+from pathlib import Path
+import re
+from scripts.seo_blocks import render_block
+path = '/moskva/arenda-vnedorozhnika-bez-voditelya'
+seo_html = render_block(path)
+index_path = Path('composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html')
+text = index_path.read_text(encoding='utf-8')
+new_text, count = re.subn(
+    r'<div class=\"drivebit-seo-shell\">[\s\S]*?</div>\s*\n',
+    seo_html, text, count=1,
+)
+index_path.write_text(new_text, encoding='utf-8')
+"
+```
+
+Блок **обязан** стоять в `index.html` перед `drivebit-footer-shell` — краулеры читают initial HTML, а не только runtime-обновление через `SeoBlocks.kt`.
+
+### 5. Статические HTML и кнопки фильтров
+
+Во всех `index.html` (корень, `moskva/*`, другие города, `composeApp/seo/filters.fragment.html`):
+
+- `data-filter-title="Внедорожник"`
+- `data-filter-path="/moskva/arenda-vnedorozhnika-bez-voditelya"` (для Москвы; для других городов — `/{city}/arenda-vnedorozhnika-bez-voditelya`)
+
+Удалить `moskva/meropriyatie/` — страница больше не используется.
+
+### 6. Sitemap и CI
+
+- `composeApp/src/jsMain/resources/sitemap.xml` — новый `<loc>`
+- `.github/workflows/deploy.yml` — slug `arenda-vnedorozhnika-bez-voditelya` в проверке Moscow SEO pages
+- `scripts/print-city-meta-table.mjs` — путь к `index.html`
+
+### 7. Тесты
+
+- `CityPathRoutingTest` — custom slug mapping
+- `CarSearchRepositoryTest` — `bodyTypes = listOf("SUV")` вместо старых полей «Мероприятие» (yearMin, dailyPriceMax)
+
+## Why This Matters
+
+- **SEO:** длинный URL и полный статический текст индексируются без ожидания JS.
+- **Фильтрация:** кнопка реально отбирает SUV через API (`BodyType=SUV`).
+- **Единый источник:** `landing-blocks.json` питает и runtime (`SeoBlocks`), и генерацию static HTML (`scripts/seo_blocks.py`).
+
+## When to Apply
+
+- Новая категория с отдельным long-tail URL (не `cityNameToSlug(shortName)`).
+- Фильтр по `bodyTypes` / другим полям каталога, а не по trip-purpose из `SuggestedFiltersCatalog`.
+- Контент приходит из Google Doc — сначала `sections` в `landing-blocks.json`, затем `render_block` в `index.html`.
+
+## Examples
+
+**Проверка на проде после релиза:**
+
+```bash
+curl -sL "https://drivebit.ru/moskva/arenda-vnedorozhnika-bez-voditelya" | rg "Пробег и дополнительные расходы|Как арендовать внедорожник|<table>"
+```
+
+Ожидается: 15× `<h2>`, 1× `<table>`, 6× `<ul>`, блок `drivebit-seo-shell` выше `drivebit-footer-shell`.
+
+## Files touched (reference)
+
+| Область | Файлы |
+|---------|--------|
+| Filter catalog | `Repositories/.../SuggestedFiltersCatalog.kt` |
+| Routing | `DrivebitWeb/.../CityPathRouting.kt`, `FiltersViewModel.kt` |
+| Meta | `MetaTags.kt`, `CityDeclensionUtils.kt`, `city-meta-bootstrap.js` |
+| Content | `composeApp/seo/landing-blocks.json` |
+| Static page | `composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html` |
+| Bulk UI | все `index.html` с filter row, `filters.fragment.html` |
+| Infra | `sitemap.xml`, `deploy.yml`, `print-city-meta-table.mjs` |
+
+## Related
+
+- [composeApp/seo/README.md](../../../composeApp/seo/README.md) — общие правила static SEO
+- [scripts/seo_blocks.py](../../../scripts/seo_blocks.py) — рендер SEO из JSON


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the Внедорожник / SUV SEO landing page work (PRs #254, #255, releases v3.16.8–v3.16.9).

- **`docs/solutions/best-practices/seo-vnedorozhnik-filter-landing-page.md`** — full checklist: filter catalog, custom slug, meta, landing-blocks.json, static HTML generation, tests, verification.
- **`composeApp/seo/README.md`** — new section «Body-type filter with custom SEO URL» with `render_block` command and link to the solution doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

