### PR TITLE
Add fetch-backend-logs workflow_dispatch

### DIFF
--- a/.github/workflows/fetch-backend-logs.yml
+++ b/.github/workflows/fetch-backend-logs.yml
@@ -1,0 +1,82 @@
+name: Fetch Backend Logs
+
+on:
+  workflow_dispatch:
+    inputs:
+      lines:
+        description: Number of log lines to tail
+        required: false
+        default: "5000"
+      pattern:
+        description: grep -E pattern (case insensitive)
+        required: false
+        default: "confirm|booking|exeed|lx|AwaitingOwner|Contract"
+
+jobs:
+  fetch-logs:
+    name: Fetch backend docker logs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch logs from backend (root@157.22.252.70)
+        id: backend_root
+        continue-on-error: true
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: 157.22.252.70
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT || 22 }}
+          script: |
+            set +e
+            echo "=== host: $(hostname) user: $(whoami) ==="
+            docker ps --format 'table {{.Names}}\t{{.Status}}' | head -20
+            CONTAINER="drivebit-drivebitbackend-1"
+            if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+              CONTAINER=$(docker ps --format '{{.Names}}' | grep -i backend | head -1)
+            fi
+            echo "=== container: ${CONTAINER:-not found} ==="
+            if [ -z "$CONTAINER" ]; then
+              exit 1
+            fi
+            docker logs --tail ${{ inputs.lines }} "$CONTAINER" 2>&1 | grep -iE "${{ inputs.pattern }}" | tail -300
+
+      - name: Fetch logs from api.drivebit.ru (user1)
+        id: backend_api
+        if: steps.backend_root.outcome != 'success'
+        continue-on-error: true
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: api.drivebit.ru
+          username: user1
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT || 22 }}
+          script: |
+            set +e
+            echo "=== host: $(hostname) user: $(whoami) ==="
+            docker ps --format 'table {{.Names}}\t{{.Status}}' | head -20
+            CONTAINER="drivebit-drivebitbackend-1"
+            if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+              CONTAINER=$(docker ps --format '{{.Names}}' | grep -i backend | head -1)
+            fi
+            echo "=== container: ${CONTAINER:-not found} ==="
+            if [ -z "$CONTAINER" ]; then
+              exit 1
+            fi
+            docker logs --tail ${{ inputs.lines }} "$CONTAINER" 2>&1 | grep -iE "${{ inputs.pattern }}" | tail -300
+
+      - name: Fetch logs via deploy host hop
+        id: backend_hop
+        if: steps.backend_root.outcome != 'success' && steps.backend_api.outcome != 'success'
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT || 22 }}
+          script: |
+            set +e
+            echo "=== deploy host: $(hostname) user: $(whoami) ==="
+            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@157.22.252.70 \
+              "docker logs --tail ${{ inputs.lines }} drivebit-drivebitbackend-1 2>&1 | grep -iE '${{ inputs.pattern }}' | tail -300" \
+              || ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 user1@api.drivebit.ru \
+              "docker logs --tail ${{ inputs.lines }} drivebit-drivebitbackend-1 2>&1 | grep -iE '${{ inputs.pattern }}' | tail -300"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Временный workflow для диагностики: `workflow_dispatch` с `SERVER_SSH_KEY` (как в deploy) — tail docker logs бэкенда с grep по booking/confirm/exeed.

Нужен для расследования ошибки подтверждения букинга Exeed LX.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

