### PR TITLE
Show backend booking confirm errors to owner

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ErrorHandler.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ErrorHandler.kt
@@ -3,24 +3,29 @@ package my.drivebit.viewmodels
 import my.drivebit.network.NetworkException
 
 object ErrorHandler {
-    fun humanizeApiError(raw: String?): String? =
-        when (raw?.trim()?.trim('"')) {
-            "AddressNotFound" ->
+    fun humanizeApiError(raw: String?): String? {
+        val normalized = raw?.trim()?.trim('"')?.takeIf { it.isNotBlank() } ?: return null
+        return when {
+            normalized.equals("AddressNotFound", ignoreCase = true) ->
                 "Адрес не найден. Укажите один город, улицу и дом — без лишних городов в строке."
-            else -> raw?.takeIf { it.isNotBlank() }
+            normalized.contains("валидированных документов", ignoreCase = true) ->
+                "Подтвердить сделку нельзя: загрузите документы в профиле и дождитесь их проверки."
+            else -> normalized
         }
+    }
 
     fun extractErrorMessage(
         exception: Throwable,
         defaultNetworkError: String = "Ошибка сети",
         defaultGenericError: String = "Произошла ошибка",
-    ): String =
-        when (exception) {
-            is NetworkException ->
-                humanizeApiError(exception.message)
-                    ?: defaultNetworkError
-            else ->
-                humanizeApiError(exception.message)
-                    ?: defaultGenericError
+    ): String {
+        val humanized = humanizeApiError(exception.message)
+        if (humanized != null) {
+            return humanized
         }
+        return when (exception) {
+            is NetworkException -> defaultNetworkError
+            else -> defaultGenericError
+        }
+    }
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModel.kt
@@ -84,6 +84,11 @@ class MyBookingsAsOwnerViewModelImpl(
             setLoading = { },
             setError = { _error.value = it },
             errorHandler = { e ->
+                logBookingActionError(
+                    action = "confirmBooking",
+                    bookingId = bookingId,
+                    exception = e,
+                )
                 ErrorHandler.extractErrorMessage(
                     exception = e,
                     defaultNetworkError = "Ошибка сети",
@@ -110,6 +115,11 @@ class MyBookingsAsOwnerViewModelImpl(
             setLoading = { },
             setError = { _error.value = it },
             errorHandler = { e ->
+                logBookingActionError(
+                    action = "declineBooking",
+                    bookingId = bookingId,
+                    exception = e,
+                )
                 ErrorHandler.extractErrorMessage(
                     exception = e,
                     defaultNetworkError = "Ошибка сети",

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/ErrorHandlerTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/ErrorHandlerTest.kt
@@ -25,4 +25,28 @@ class ErrorHandlerTest {
             message,
         )
     }
+
+    @Test
+    fun `extractErrorMessage humanizes missing validated documents message`() {
+        val message =
+            ErrorHandler.extractErrorMessage(
+                NetworkException(
+                    HttpStatusCode.OK,
+                    "Владелец не может подтвердить бронирование: нет валидированных документов",
+                ),
+            )
+        assertEquals(
+            "Подтвердить сделку нельзя: загрузите документы в профиле и дождитесь их проверки.",
+            message,
+        )
+    }
+
+    @Test
+    fun `extractErrorMessage passes through unknown api message`() {
+        val message =
+            ErrorHandler.extractErrorMessage(
+                NetworkException(HttpStatusCode.BadRequest, "Сделка уже подтверждена"),
+            )
+        assertEquals("Сделка уже подтверждена", message)
+    }
 }

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/MyBookingsAsOwnerViewModelTest.kt
@@ -42,7 +42,14 @@ private class MyBookingsFakeBooking(
 
     override suspend fun createAsRenter(request: CreateBookingRequest): BookingDTO = throw NotImplementedError()
 
-    override suspend fun confirmAsOwner(bookingId: String) = throw NotImplementedError()
+    override suspend fun confirmAsOwner(bookingId: String) {
+        if (bookingId == "booking-fail") {
+            throw NetworkException(
+                HttpStatusCode.OK,
+                "нет валидированных документов",
+            )
+        }
+    }
 
     override suspend fun declineAsOwner(bookingId: String) = throw NotImplementedError()
 
@@ -100,5 +107,27 @@ class MyBookingsAsOwnerViewModelTest {
             assertTrue(updatedBooking.contractSignedByOwner)
             assertFalse(updatedBooking.canSignContractAsOwner)
             assertEquals("ContractSignedByOwner", updatedBooking.status)
+        }
+
+    @Test
+    fun `confirmBooking surfaces backend error message`() =
+        runTest(StandardTestDispatcher()) {
+            val bookingId = "booking-fail"
+            val fakeBooking =
+                MyBookingsFakeBooking(
+                    ownerBookings = listOf(sampleBooking(bookingId)),
+                )
+            val testScope = CoroutineScope(SupervisorJob() + coroutineContext)
+            val viewModel = MyBookingsAsOwnerViewModelImpl(fakeBooking, testScope)
+
+            viewModel.loadBookings()
+            advanceUntilIdle()
+            viewModel.confirmBooking(bookingId)
+            advanceUntilIdle()
+
+            assertEquals(
+                "Подтвердить сделку нельзя: загрузите документы в профиле и дождитесь их проверки.",
+                viewModel.error.value,
+            )
         }
 }

--- a/Network/src/commonMain/kotlin/my/drivebit/network/HttpResponseExtensions.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/HttpResponseExtensions.kt
@@ -26,60 +26,78 @@ data class ValidationErrorResponse(
     val error: String? = null,
 )
 
+@kotlinx.serialization.Serializable
+data class ApiMessageDto(
+    val success: Boolean? = null,
+    val message: String? = null,
+)
+
+fun extractHttpErrorMessage(
+    bodyString: String,
+    json: Json = defaultJson,
+): String {
+    val trimmedBody = bodyString.trim()
+    return runCatching {
+        if (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) {
+            val errorResponse = json.decodeFromString<ValidationErrorResponse>(trimmedBody)
+            val errorMessages = errorResponse.errors?.collectErrorMessages().orEmpty()
+            when {
+                !errorResponse.message.isNullOrBlank() -> errorResponse.message
+                errorMessages.isNotEmpty() -> errorMessages.joinToString(". ")
+                !errorResponse.detail.isNullOrBlank() -> errorResponse.detail
+                !errorResponse.error.isNullOrBlank() -> errorResponse.error
+                !errorResponse.title.isNullOrBlank() -> errorResponse.title
+                else -> trimmedBody.trim('"').trim()
+            }
+        } else {
+            trimmedBody.trim('"').trim()
+        }
+    }.getOrElse {
+        trimmedBody.trim('"').trim()
+    }
+}
+
 suspend inline fun <reified T> HttpResponse.parseResponse(json: Json = defaultJson): T {
     val bodyString = bodyAsText()
 
     if (!status.isSuccess()) {
-        val errorMessage =
-            runCatching {
-                val trimmedBody = bodyString.trim()
-                if (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) {
-                    val errorResponse = json.decodeFromString<ValidationErrorResponse>(trimmedBody)
-                    val errorMessages = errorResponse.errors?.collectErrorMessages().orEmpty()
-                    when {
-                        !errorResponse.message.isNullOrBlank() -> errorResponse.message
-                        errorMessages.isNotEmpty() -> errorMessages.joinToString(". ")
-                        errorResponse.detail != null -> errorResponse.detail
-                        errorResponse.error != null -> errorResponse.error
-                        errorResponse.title != null -> errorResponse.title
-                        else -> trimmedBody.trim('"').trim()
-                    }
-                } else {
-                    trimmedBody.trim('"').trim()
-                }
-            }.getOrElse {
-                bodyString.trim('"').trim()
-            }
-        throw NetworkException(status, errorMessage)
+        throw NetworkException(status, extractHttpErrorMessage(bodyString, json))
     }
 
     return json.decodeFromString<T>(bodyString)
 }
 
-suspend fun HttpResponse.consumeResponse() {
+suspend fun HttpResponse.consumeResponse(json: Json = defaultJson) {
     val bodyString = bodyAsText()
     if (!status.isSuccess()) {
-        val errorMessage =
-            runCatching {
-                val trimmedBody = bodyString.trim()
-                if (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) {
-                    val errorResponse = defaultJson.decodeFromString<ValidationErrorResponse>(trimmedBody)
-                    val errorMessages = errorResponse.errors?.collectErrorMessages().orEmpty()
-                    when {
-                        !errorResponse.message.isNullOrBlank() -> errorResponse.message
-                        errorMessages.isNotEmpty() -> errorMessages.joinToString(". ")
-                        errorResponse.detail != null -> errorResponse.detail
-                        errorResponse.error != null -> errorResponse.error
-                        errorResponse.title != null -> errorResponse.title
-                        else -> trimmedBody.trim('"').trim()
-                    }
-                } else {
-                    trimmedBody.trim('"').trim()
-                }
-            }.getOrElse {
-                bodyString.trim('"').trim()
-            }
-        throw NetworkException(status, errorMessage)
+        throw NetworkException(status, extractHttpErrorMessage(bodyString, json))
+    }
+}
+
+suspend fun HttpResponse.consumeMessageResponse(
+    defaultError: String = "Операция не выполнена",
+    json: Json = defaultJson,
+) {
+    val bodyString = bodyAsText()
+    if (!status.isSuccess()) {
+        throw NetworkException(status, extractHttpErrorMessage(bodyString, json))
+    }
+
+    val trimmedBody = bodyString.trim()
+    if (!trimmedBody.startsWith("{") || !trimmedBody.endsWith("}")) {
+        return
+    }
+
+    val messageDto =
+        runCatching {
+            json.decodeFromString<ApiMessageDto>(trimmedBody)
+        }.getOrNull() ?: return
+
+    if (messageDto.success == false) {
+        throw NetworkException(
+            status,
+            messageDto.message?.takeIf { it.isNotBlank() } ?: defaultError,
+        )
     }
 }
 

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Booking.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.JsonNames
 import my.drivebit.network.DEFAULT_BASE_URL
 import my.drivebit.network.ValidationErrorResponse
 import my.drivebit.network.collectErrorMessages
-import my.drivebit.network.consumeResponse
+import my.drivebit.network.consumeMessageResponse
 import my.drivebit.network.defaultJson
 import my.drivebit.network.parseResponse
 import my.drivebit.utils.resolveMinioImageUrlForBrowser
@@ -271,13 +271,13 @@ class BookingImpl(
     override suspend fun confirmAsOwner(bookingId: String) {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/confirm"
         val response = authorizedHttpClient.put(url) { }
-        response.consumeResponse()
+        response.consumeMessageResponse(defaultError = "Не удалось подтвердить сделку")
     }
 
     override suspend fun declineAsOwner(bookingId: String) {
         val url = "${DEFAULT_BASE_URL}Booking/my/as-owner/$bookingId/decline"
         val response = authorizedHttpClient.put(url) { }
-        response.consumeResponse()
+        response.consumeMessageResponse(defaultError = "Не удалось отклонить сделку")
     }
 
     override suspend fun signContractAsOwner(bookingId: String): BookingDTO {

--- a/Network/src/commonTest/kotlin/my/drivebit/network/HttpResponseExtensionsTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/HttpResponseExtensionsTest.kt
@@ -1,0 +1,62 @@
+package my.drivebit.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.put
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class HttpResponseExtensionsTest {
+    @Test
+    fun `consumeMessageResponse throws when success is false`() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = """{"success":false,"message":"нет валидированных документов"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val httpClient = HttpClient(mockEngine)
+
+            val exception =
+                assertFailsWith<NetworkException> {
+                    httpClient.put("https://example.com/confirm").consumeMessageResponse()
+                }
+
+            assertEquals(HttpStatusCode.OK, exception.statusCode)
+            assertEquals("нет валидированных документов", exception.message)
+        }
+
+    @Test
+    fun `consumeMessageResponse succeeds when success is true`() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = """{"success":true,"message":"OK"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val httpClient = HttpClient(mockEngine)
+
+            httpClient.put("https://example.com/confirm").consumeMessageResponse()
+        }
+
+    @Test
+    fun `extractHttpErrorMessage reads message field from validation response`() {
+        val message =
+            extractHttpErrorMessage(
+                """{"message":"Недостаточно прав"}""",
+            )
+        assertEquals("Недостаточно прав", message)
+    }
+}

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingConfirmTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/BookingConfirmTest.kt
@@ -1,0 +1,43 @@
+package my.drivebit.network.services
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import my.drivebit.network.NetworkException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class BookingConfirmTest {
+    @Test
+    fun `confirmAsOwner throws when api returns success false`() =
+        runTest {
+            val bookingId = "c5db17ad-d87f-436f-ae25-12213f114667"
+            var requestedPath: String? = null
+            val mockEngine =
+                MockEngine { request ->
+                    requestedPath = request.url.encodedPath
+                    assertEquals(HttpMethod.Put, request.method)
+                    respond(
+                        content = """{"success":false,"message":"нет валидированных документов"}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val booking = BookingImpl(HttpClient(mockEngine), HttpClient(mockEngine))
+
+            val exception =
+                assertFailsWith<NetworkException> {
+                    booking.confirmAsOwner(bookingId)
+                }
+
+            assertTrue(requestedPath!!.endsWith("/Booking/my/as-owner/$bookingId/confirm"))
+            assertEquals("нет валидированных документов", exception.message)
+        }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Owners saw a generic «Не удалось подтвердить сделку» (or no error at all) when backend rejected confirmation — for example when documents are not validated.

Root cause: `PUT /Booking/my/as-owner/{id}/confirm` returns HTTP 200 with `MessageDTO` (`success: false`, `message: "..."`). `consumeResponse()` only checked HTTP status and ignored the body.

## Changes

- Add `consumeMessageResponse()` to parse `MessageDTO` and throw `NetworkException` when `success == false`
- Use it in `confirmAsOwner` / `declineAsOwner`
- Humanize «нет валидированных документов» → «Подтвердить сделку нельзя: загрузите документы в профиле и дождитесь их проверки.»
- Log confirm/decline failures in `MyBookingsAsOwnerViewModel` (same as sign contract)
- Tests for network parsing, ErrorHandler, ViewModel, and Booking service

## Verification

- `./gradlew :Network:jsTest :CommonViewModels:jsTest` — BUILD SUCCESSFUL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

