### PR TITLE
Sync hero headline from URL path on filter change

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/web/HeroHeadlineForPath.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/web/HeroHeadlineForPath.kt
@@ -1,0 +1,21 @@
+package my.drivebit.web
+
+import my.drivebit.utils.cityNameFromSlug
+import my.drivebit.utils.pageHeadline
+
+fun heroHeadlineForCityPath(path: String): String? {
+    val cityPath = parseCityPath(path) ?: return null
+    val cityName = cityNameFromSlug(cityPath.citySlug) ?: return null
+    val filterTitle = filterTitleFromPathSegment(cityPath.filterSlug)
+    return pageHeadline(
+        citySlug = cityPath.citySlug,
+        filterSlug = cityPath.filterSlug,
+        cityName = cityName,
+        filterTitle = filterTitle,
+    )
+}
+
+fun activeFilterTitleForCityPath(path: String): String? {
+    val cityPath = parseCityPath(path) ?: return null
+    return filterTitleFromPathSegment(cityPath.filterSlug)
+}

--- a/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/HeroHeadlineForPathTest.kt
+++ b/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/HeroHeadlineForPathTest.kt
@@ -1,0 +1,49 @@
+package my.drivebit.web
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class HeroHeadlineForPathTest {
+    @Test
+    fun heroHeadlineForCityPath_moskvaRoot() {
+        assertEquals(
+            "Аренда авто у частных владельцев в Москве",
+            heroHeadlineForCityPath("/moskva"),
+        )
+    }
+
+    @Test
+    fun heroHeadlineForCityPath_changesWhenFilterSegmentChanges() {
+        val rootHeadline = heroHeadlineForCityPath("/moskva")
+        val krymHeadline = heroHeadlineForCityPath("/moskva/arenda-avto-v-krym")
+
+        assertNotNull(rootHeadline)
+        assertNotNull(krymHeadline)
+        assertNotEquals(rootHeadline, krymHeadline)
+        assertEquals("Аренда авто для поездки в Крым из Москвы", krymHeadline)
+    }
+
+    @Test
+    fun heroHeadlineForCityPath_ignoresQueryString() {
+        assertEquals(
+            heroHeadlineForCityPath("/moskva/arenda-avto-v-krym"),
+            heroHeadlineForCityPath("/moskva/arenda-avto-v-krym?startDate=2026-07-01"),
+        )
+    }
+
+    @Test
+    fun heroHeadlineForCityPath_returnsNullForNonCityPath() {
+        assertNull(heroHeadlineForCityPath("/search"))
+        assertNull(heroHeadlineForCityPath("/profile"))
+    }
+
+    @Test
+    fun activeFilterTitleForCityPath_readsOnlyFromPath() {
+        assertEquals("Все", activeFilterTitleForCityPath("/moskva"))
+        assertEquals("В Крым", activeFilterTitleForCityPath("/moskva/arenda-avto-v-krym"))
+        assertEquals("Поблизости", activeFilterTitleForCityPath("/moskva/poblizosti"))
+    }
+}

--- a/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/clients/App.kt
@@ -15,6 +15,7 @@ import my.drivebit.screens.SearchPage
 import my.drivebit.shell.MountWebShell
 import my.drivebit.shell.isStaticHtmlShellPath
 import my.drivebit.web.StaticFiltersShellSync
+import my.drivebit.web.StaticHeroHeadlineSync
 import my.drivebit.web.StaticHeroShellSync
 import my.drivebit.web.StaticMainPromoShellSync
 import my.drivebit.web.isCityHomePath
@@ -28,6 +29,7 @@ actual fun App() {
         CookieConsentBanner()
         Navigation { currentPath ->
             StaticHeroShellSync(currentPath)
+            StaticHeroHeadlineSync(currentPath)
             StaticFiltersShellSync(currentPath)
             StaticMainPromoShellSync(currentPath)
             when {

--- a/composeApp/src/jsMain/kotlin/my/drivebit/web/HtmlFiltersBridge.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/web/HtmlFiltersBridge.kt
@@ -55,7 +55,9 @@ fun HtmlFiltersBridge(
         }
 
         val pathListener: (Event) -> Unit = {
-            syncStaticFiltersPressedState(filterTitleFromPathSegment(parseFilterSlugFromCityPath(window.location.pathname)))
+            val path = window.location.pathname
+            activeFilterTitleForCityPath(path)?.let { syncStaticFiltersPressedState(it) }
+            heroHeadlineForCityPath(path)?.let { syncStaticHeroHeadlineText(it) }
         }
 
         window.addEventListener("drivebit-filter-select", selectListener)
@@ -68,14 +70,10 @@ fun HtmlFiltersBridge(
         }
     }
 
-    LaunchedEffect(currentPath, filterState.selected) {
-        val fromPath =
-            parseFilterSlugFromCityPath(currentPath)?.let { slug ->
-                filterState.filters.firstOrNull { filterTitleToPathSegment(it.title) == slug }?.title
-            }
-        val active = fromPath ?: filterState.selected
-        syncStaticFiltersPressedState(active)
-        syncStaticHeroBackground(active, filterState.filters)
+    LaunchedEffect(currentPath, filterState.filters) {
+        val activeFromPath = activeFilterTitleForCityPath(currentPath) ?: return@LaunchedEffect
+        syncStaticFiltersPressedState(activeFromPath)
+        syncStaticHeroBackground(activeFromPath, filterState.filters)
         window.dispatchEvent(org.w3c.dom.events.Event("drivebit-filter-path-changed"))
     }
 }

--- a/composeApp/src/jsMain/kotlin/my/drivebit/web/StaticHeroHeadlineSync.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/web/StaticHeroHeadlineSync.kt
@@ -1,0 +1,22 @@
+package my.drivebit.web
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
+
+@Composable
+fun StaticHeroHeadlineSync(currentPath: String) {
+    LaunchedEffect(currentPath) {
+        if (!shouldShowStaticHeroShell(currentPath)) return@LaunchedEffect
+        if (document.getElementById("drivebit-hero-headline") == null) return@LaunchedEffect
+        heroHeadlineForCityPath(currentPath)?.let { syncStaticHeroHeadlineText(it) }
+    }
+}
+
+fun syncStaticHeroHeadlineText(headline: String) {
+    val element = document.getElementById("drivebit-hero-headline") as? HTMLElement ?: return
+    if (element.textContent != headline) {
+        element.textContent = headline
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicking trip filter buttons changed the URL but the static hero `<h1>` stayed on the initial page text.

## Fix

- `heroHeadlineForCityPath(path)` — headline is derived **only from the URL path** (city slug + filter slug)
- `StaticHeroHeadlineSync` — updates `#drivebit-hero-headline` on every city path change
- `HtmlFiltersBridge` — pressed filter state and hero background also follow path, not ViewModel selection

## Tests

- `HeroHeadlineForPathTest` — `/moskva` vs `/moskva/arenda-avto-v-krym` produce different headlines

## Verification

- `./gradlew :DrivebitWeb:jsTest` — BUILD SUCCESSFUL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

