### PR TITLE
Lazy-load car grid photos below the first screen

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarGridImageLoading.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarGridImageLoading.kt
@@ -1,0 +1,17 @@
+package my.drivebit.components
+
+const val CAR_GRID_EAGER_MOBILE_COUNT = 2
+const val CAR_GRID_EAGER_DESKTOP_COUNT = 3
+
+fun carGridImageLoadsEagerly(
+    gridIndex: Int,
+    isMobileViewport: Boolean,
+): Boolean {
+    val eagerCount = if (isMobileViewport) CAR_GRID_EAGER_MOBILE_COUNT else CAR_GRID_EAGER_DESKTOP_COUNT
+    return gridIndex < eagerCount
+}
+
+fun carGridImageLoadingAttr(
+    gridIndex: Int,
+    isMobileViewport: Boolean,
+): String = if (carGridImageLoadsEagerly(gridIndex, isMobileViewport)) "eager" else "lazy"

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarItemSmall.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarItemSmall.kt
@@ -20,11 +20,13 @@ import org.jetbrains.compose.web.dom.Text
 fun CarItemSmall(
     car: CarItem,
     href: String? = null,
+    gridIndex: Int = 0,
 ) {
     var isImageHovered by remember { mutableStateOf(false) }
     var currentPhotoIndex by remember { mutableStateOf(0) }
     var touchStartX by remember { mutableStateOf<Double?>(null) }
     val isMobileViewport = window.innerWidth <= 768
+    val imageLoadsEagerly = carGridImageLoadsEagerly(gridIndex, isMobileViewport)
 
     val cardContent: @Composable () -> Unit = {
         Column(
@@ -60,6 +62,11 @@ fun CarItemSmall(
                     Img(
                         src = currentPhotoUrl,
                         attrs = {
+                            attr("loading", carGridImageLoadingAttr(gridIndex, isMobileViewport))
+                            attr("decoding", "async")
+                            if (!imageLoadsEagerly) {
+                                attr("fetchpriority", "low")
+                            }
                             if (isMobileViewport) {
                                 onTouchStart { event ->
                                     touchStartX =

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarsGrid.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarsGrid.kt
@@ -26,11 +26,12 @@ fun CarsGrid(
             width(100.percent)
         }
     }) {
-        cars.forEach { car ->
+        cars.forEachIndexed { index, car ->
             Column {
                 CarItemSmall(
                     car = car,
                     href = carHref(car),
+                    gridIndex = index,
                 )
             }
         }

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyCarsPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/MyCarsPage.kt
@@ -84,11 +84,12 @@ fun MyCarsPage() {
 
                     else -> {
                         Column(gap = 16.px) {
-                            cars.forEach { car ->
+                            cars.forEachIndexed { index, car ->
                                 Column(gap = 12.px) {
                                     CarItemSmall(
                                         car = car,
                                         href = buildCarDetailUrl(car.id),
+                                        gridIndex = index,
                                     )
                                     Row(justifyContent = JustifyContent.Center) {
                                         ActionButton(

--- a/DrivebitWeb/src/jsTest/kotlin/my/drivebit/components/CarGridImageLoadingTest.kt
+++ b/DrivebitWeb/src/jsTest/kotlin/my/drivebit/components/CarGridImageLoadingTest.kt
@@ -1,0 +1,29 @@
+package my.drivebit.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CarGridImageLoadingTest {
+    @Test
+    fun `mobile first two cards load eagerly`() {
+        assertTrue(carGridImageLoadsEagerly(0, isMobileViewport = true))
+        assertTrue(carGridImageLoadsEagerly(1, isMobileViewport = true))
+        assertFalse(carGridImageLoadsEagerly(2, isMobileViewport = true))
+    }
+
+    @Test
+    fun `desktop first three cards load eagerly`() {
+        assertTrue(carGridImageLoadsEagerly(0, isMobileViewport = false))
+        assertTrue(carGridImageLoadsEagerly(2, isMobileViewport = false))
+        assertFalse(carGridImageLoadsEagerly(3, isMobileViewport = false))
+    }
+
+    @Test
+    fun `loading attr maps to eager or lazy`() {
+        assertEquals("eager", carGridImageLoadingAttr(0, isMobileViewport = true))
+        assertEquals("lazy", carGridImageLoadingAttr(2, isMobileViewport = true))
+        assertEquals("lazy", carGridImageLoadingAttr(5, isMobileViewport = false))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ускоряет холодную загрузку на мобилке: фото машин вне первого экрана больше не скачиваются сразу при открытии `/moskva`.

## Changes

- `CarGridImageLoading.kt` — правила eager/lazy: 2 карточки на mobile, 3 на desktop
- `CarItemSmall` — `loading="lazy"`, `decoding="async"`, `fetchpriority="low"` для off-screen карточек
- `CarsGrid` / `MyCarsPage` — передают `gridIndex` в карточку
- Тесты `CarGridImageLoadingTest`

## Verification

- `./gradlew :DrivebitWeb:jsTest` — BUILD SUCCESSFUL

## Expected impact

- Cold load mobile 4G: −5–7 MB начального трафика (9 фото → 2 eager)
- networkidle: с ~40s до ~5–10s (без скролла)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ff2d3a-e364-4f55-9cbc-b61319d130da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

