### PR TITLE
Fix Premium path on Комфорт page

### DIFF
--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
@@ -116,7 +116,7 @@
       <button type="button" class="drivebit-filter-btn" data-filter-title="Абхазия" data-hero-bg="/images/searchbackground/car5.jpg" data-filter-path="/moskva/arenda-avto-v-abkhaziyu" aria-pressed="false">
         <span class="drivebit-filter-label">Абхазия</span>
       </button>
-      <button type="button" class="drivebit-filter-btn" data-filter-title="Премиум" data-hero-bg="/images/searchbackground/car5.jpg" data-filter-path="/moskva/arenda-avto-komfort-klassa-bez-voditelya" aria-pressed="false">
+      <button type="button" class="drivebit-filter-btn" data-filter-title="Премиум" data-hero-bg="/images/searchbackground/car3.jpg" data-filter-path="/moskva/arenda-avto-premium-klassa-bez-voditelya" aria-pressed="false">
         <span class="drivebit-filter-label">Премиум</span>
       </button>
       <button type="button" class="drivebit-filter-btn" data-filter-title="Эконом" data-hero-bg="/images/searchbackground/car6.jpg" data-filter-path="/moskva/arenda-avto-ekonom-klassa-bez-voditelya" aria-pressed="false">


### PR DESCRIPTION
## Summary
- На странице Комфорт у кнопки Премиум ошибочно стоял `data-filter-path` Комфорт, из‑за этого JS выделял Премиум
- Восстановлены path и hero background для кнопки Премиум

## Test plan
- [ ] CI green
- [ ] После деплоя: на `/moskva/arenda-avto-komfort-klassa-bez-voditelya` активна кнопка Комфорт


Made with [Cursor](https://cursor.com)