### PR TITLE
Fix Комфорт/Бизнес highlight on short filter URLs

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/web/CityPathRouting.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/web/CityPathRouting.kt
@@ -49,6 +49,8 @@ fun filterTitleFromPathSegment(filterSlug: String?): String {
         ?.key
         ?.let { return it }
     return KNOWN_FILTER_TITLES.firstOrNull { filterTitleToPathSegment(it) == normalized }
+        // Short transliteration aliases: /moskva/komfort, /moskva/biznes
+        ?: KNOWN_FILTER_TITLES.firstOrNull { cityNameToSlug(it) == normalized }
         ?: ALL_FILTER_TITLE
 }
 
@@ -65,4 +67,16 @@ fun cityPathWithFilter(
     } else {
         "/$citySlug/$filterSegment"
     }
+}
+
+/**
+ * Canonical city+filter path. Rewrites short aliases (`/moskva/komfort`) to SEO slugs.
+ * Returns null for non-city paths or unknown filter segments.
+ */
+fun canonicalCityFilterPath(path: String): String? {
+    val cityPath = parseCityPath(path) ?: return null
+    val filterSlug = cityPath.filterSlug ?: return "/${cityPath.citySlug}"
+    val filterTitle = filterTitleFromPathSegment(filterSlug)
+    if (filterTitle == ALL_FILTER_TITLE) return null
+    return cityPathWithFilter(cityPath.citySlug, filterTitle)
 }

--- a/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/CityPathRoutingTest.kt
+++ b/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/CityPathRoutingTest.kt
@@ -156,6 +156,32 @@ class CityPathRoutingTest {
     }
 
     @Test
+    fun filterTitleFromPathSegment_acceptsShortTransliterationAliases() {
+        // SPA / bookmarks may still land on cityNameToSlug paths like /moskva/komfort
+        assertEquals("Комфорт", filterTitleFromPathSegment("komfort"))
+        assertEquals("Бизнес", filterTitleFromPathSegment("biznes"))
+        assertEquals("Премиум", filterTitleFromPathSegment("premium"))
+        assertEquals("Эконом", filterTitleFromPathSegment("ekonom"))
+    }
+
+    @Test
+    fun canonicalCityFilterPath_rewritesShortAliasesToSeoSlugs() {
+        assertEquals(
+            "/moskva/arenda-avto-komfort-klassa-bez-voditelya",
+            canonicalCityFilterPath("/moskva/komfort"),
+        )
+        assertEquals(
+            "/moskva/arenda-avto-biznes-klassa-bez-voditelya",
+            canonicalCityFilterPath("/moskva/biznes"),
+        )
+        assertEquals(
+            "/moskva/arenda-avto-komfort-klassa-bez-voditelya",
+            canonicalCityFilterPath("/moskva/arenda-avto-komfort-klassa-bez-voditelya"),
+        )
+        assertNull(canonicalCityFilterPath("/profile"))
+    }
+
+    @Test
     fun cityPathWithFilter_vnedorozhnikUsesSeoSlug() {
         assertEquals(
             "/moskva/arenda-vnedorozhnika-bez-voditelya",

--- a/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/HeroHeadlineForPathTest.kt
+++ b/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/HeroHeadlineForPathTest.kt
@@ -47,6 +47,8 @@ class HeroHeadlineForPathTest {
         assertEquals("Поблизости", activeFilterTitleForCityPath("/moskva/poblizosti"))
         assertEquals("Комфорт", activeFilterTitleForCityPath("/moskva/arenda-avto-komfort-klassa-bez-voditelya"))
         assertEquals("Бизнес", activeFilterTitleForCityPath("/moskva/arenda-avto-biznes-klassa-bez-voditelya"))
+        assertEquals("Комфорт", activeFilterTitleForCityPath("/moskva/komfort"))
+        assertEquals("Бизнес", activeFilterTitleForCityPath("/moskva/biznes"))
     }
 
     @Test

--- a/composeApp/src/jsMain/kotlin/my/drivebit/clients/HomePage.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/clients/HomePage.kt
@@ -39,6 +39,7 @@ import my.drivebit.viewmodels.NearbyLayoutMode
 import my.drivebit.web.HtmlFiltersBridge
 import my.drivebit.web.HtmlHeroDatesBridge
 import my.drivebit.web.cityPathWithFilter
+import my.drivebit.web.filterTitleFromPathSegment
 import my.drivebit.web.filterTitleToPathSegment
 import my.drivebit.web.isCityHomePath
 import my.drivebit.web.buildCarDetailUrl
@@ -91,7 +92,12 @@ fun HomePage() {
     val filters = state.value.filters
     val selectedFromPath =
         parseFilterSlugFromCityPath(currentPath)?.let { filterSlug ->
-            filters.firstOrNull { filterTitleToPathSegment(it.title) == filterSlug }?.title
+            val fromSegment = filterTitleFromPathSegment(filterSlug)
+            if (fromSegment != "Все") {
+                filters.firstOrNull { it.title == fromSegment }?.title
+            } else {
+                filters.firstOrNull { filterTitleToPathSegment(it.title) == filterSlug }?.title
+            }
         }
     val selected = selectedFromPath ?: state.value.selected
 

--- a/composeApp/src/jsMain/kotlin/my/drivebit/web/HtmlFiltersBridge.kt
+++ b/composeApp/src/jsMain/kotlin/my/drivebit/web/HtmlFiltersBridge.kt
@@ -71,6 +71,12 @@ fun HtmlFiltersBridge(
     }
 
     LaunchedEffect(currentPath, filterState.filters) {
+        val canonical = canonicalCityFilterPath(currentPath)
+        if (canonical != null && canonical != currentPath) {
+            window.history.replaceState(null, "", canonical + window.location.search)
+            navigationState.updatePath(canonical)
+            return@LaunchedEffect
+        }
         val activeFromPath = activeFilterTitleForCityPath(currentPath) ?: return@LaunchedEffect
         syncStaticFiltersPressedState(activeFromPath)
         syncStaticHeroBackground(activeFromPath, filterState.filters)

--- a/vendor/drivebit-filters.js
+++ b/vendor/drivebit-filters.js
@@ -62,6 +62,19 @@
         syncHeroBackground(nav, activeTitle);
     }
 
+    // cityNameToSlug aliases for filters that also have longer SEO path segments
+    var SHORT_TITLE_BY_SLUG = {
+        komfort: "Комфорт",
+        biznes: "Бизнес",
+        premium: "Премиум",
+        ekonom: "Эконом",
+        vnedorozhnik: "Внедорожник",
+        miniven: "Минивэн",
+        "v-krym": "В Крым",
+        belarus: "Беларусь",
+        abkhaziya: "Абхазия",
+    };
+
     function titleFromPath(pathname) {
         var path = normalizePath(pathname);
         var nav = qs("drivebit-filters-static");
@@ -72,6 +85,15 @@
             var filterPath = btn.getAttribute("data-filter-path");
             if (filterPath && normalizePath(filterPath) === path) {
                 return btn.getAttribute("data-filter-title") || "Все";
+            }
+        }
+        var segment = path.split("/").pop() || "";
+        var aliasTitle = SHORT_TITLE_BY_SLUG[segment];
+        if (aliasTitle) {
+            for (var j = 0; j < buttons.length; j++) {
+                if ((buttons[j].getAttribute("data-filter-title") || "") === aliasTitle) {
+                    return aliasTitle;
+                }
             }
         }
         return "Все";


### PR DESCRIPTION
## Summary
- `/moskva/komfort` и `/moskva/biznes` не резолвились в «Комфорт»/«Бизнес» → кнопка не белела
- `filterTitleFromPathSegment` принимает short transliteration aliases
- `canonicalCityFilterPath` переписывает short → SEO slug
- JS `titleFromPath` + HomePage path sync тоже понимают aliases

## Test plan
- [x] Unit: `filterTitleFromPathSegment("komfort"|"biznes")`
- [x] Unit: `canonicalCityFilterPath("/moskva/komfort")`
- [x] Unit: `activeFilterTitleForCityPath("/moskva/komfort")`
- [ ] Prod: открыть `/moskva/komfort` → chip «Комфорт» белый, URL → SEO slug


Made with [Cursor](https://cursor.com)