### PR TITLE
fix(web): restore Callibri — classic defer loader

### DIFF
--- a/.cursor/skills/drivebit-ship-release/SKILL.md
+++ b/.cursor/skills/drivebit-ship-release/SKILL.md
@@ -114,9 +114,40 @@ gh run watch <run-id> --exit-status
 
 Deploy takes ~10–12 min. Success = `conclusion: success`.
 
-### 9. Post-deploy verify (when applicable)
+### 9. Post-deploy prod smoke (required)
 
-Spot-check prod URLs or API behavior changed by the release. Report release URL + deploy run URL.
+**Do not announce «на проде» until this step passes.**
+
+Run automated smoke against production:
+
+```bash
+npm install   # if node_modules missing locally
+npm run verify:prod-smoke
+```
+
+Default base URL: `https://drivebit.ru`. Exit code **0** required.
+
+**What the smoke test checks:**
+
+| Check | Gate |
+|-------|------|
+| HTTP 200 | `/moskva`, `/search`, `/login`, `/contacts`, `/list-your-car.html` |
+| Compose mount | `#root` has content on `/moskva` and `/search` |
+| Third-party loader | `drivebit-third-party-deferred.js` in HTML on all key pages |
+| Navigation | Hero button «Найти автомобиль» opens `/search` |
+| Vendor assets | `/vendor/drivebit-third-party-deferred.js` served (classic `defer`, not `type=module`) |
+| JS errors | No `pageerror` on any checked page |
+
+**Analytics note:** Metrika/Callibri may not load in headless Playwright (ad-block / external scripts). The smoke script reports `analytics` info but does not fail on it. For analytics-only releases, additionally spot-check in a real browser: Network tab → `metrika/tag.js` before `callibri.js`.
+
+**Optional manual spot-check** (browser or `cursor-ide-browser`):
+
+1. https://drivebit.ru/moskva — hero, filters, car grid render
+2. Click «Найти автомобиль» → `/search` with results UI
+3. Header links: «Контакты», «Сдать авто»
+4. https://drivebit.ru/login — auth shell loads (may redirect if already logged in)
+
+Report in final message: release URL + deploy run URL + smoke test output summary.
 
 ## Quick Reference
 
@@ -128,6 +159,7 @@ Spot-check prod URLs or API behavior changed by the release. Report release URL 
 | Merge | `gh pr merge --merge` |
 | Release | `gh release create v3.16.NN --target trunk` |
 | Deploy | `gh run watch` on latest `deploy.yml` |
+| Prod smoke | `npm run verify:prod-smoke` → exit 0 |
 
 ## Common Mistakes
 
@@ -137,12 +169,14 @@ Spot-check prod URLs or API behavior changed by the release. Report release URL 
 | `git add -A` sweeps junk | Stage paths explicitly |
 | Merge before CI green | Wait for `gh pr checks --watch` |
 | Skip deploy watch | Release ≠ deployed until `deploy.yml` succeeds |
+| Skip prod smoke | Deploy success ≠ site works; run `npm run verify:prod-smoke` |
 | Wrong version | Always read `gh release list --limit 1` first |
 | Broad local `./gradlew check` for CI debug | Run only the failing module/task from the log |
 
 ## Red Flags — STOP
 
 - Announcing «готово» / «на проде» without deploy run exit code 0
+- Announcing «на проде» without `npm run verify:prod-smoke` exit code 0
 - Pushing to `trunk` directly (except emergency hotfix per `.cursorrules`)
 - Creating release before merge to `trunk`
 - Leaving unrelated files in the commit

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/analytics/YandexMetrica.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/analytics/YandexMetrica.kt
@@ -22,7 +22,7 @@ private fun ensureYandexMetrikaStub() {
     }
     val script = document.createElement("script") as HTMLScriptElement
     script.src = DEFERRED_LOADER_PATH
-    script.type = "module"
+    script.defer = true
     document.head?.appendChild(script)
 }
 

--- a/authApp/src/jsMain/resources/auth-app-shell/index.html
+++ b/authApp/src/jsMain/resources/auth-app-shell/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-split-app-shell.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-split-app-shell">
     <!-- drivebit-app-header-start -->

--- a/carDetailApp/src/jsMain/resources/car-detail/index.html
+++ b/carDetailApp/src/jsMain/resources/car-detail/index.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-split-app-shell.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-split-app-shell">
 <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/contacts/index.html
+++ b/composeApp/src/jsMain/resources/contacts/index.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/cookies/index.html
+++ b/composeApp/src/jsMain/resources/cookies/index.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/kaliningrad/index.html
+++ b/composeApp/src/jsMain/resources/kaliningrad/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/krasnogorsk/index.html
+++ b/composeApp/src/jsMain/resources/krasnogorsk/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/lyubertsy/index.html
+++ b/composeApp/src/jsMain/resources/lyubertsy/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-biznes-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-biznes-klassa-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-premium-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-premium-klassa-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-abkhaziyu/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-abkhaziyu/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-belarus/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-belarus/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-krym/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-krym/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-minivena-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-minivena-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/index.html
+++ b/composeApp/src/jsMain/resources/moskva/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/moskva/poblizosti/index.html
+++ b/composeApp/src/jsMain/resources/moskva/poblizosti/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/offer/index.html
+++ b/composeApp/src/jsMain/resources/offer/index.html
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
 

--- a/composeApp/src/jsMain/resources/payment-failure/index.html
+++ b/composeApp/src/jsMain/resources/payment-failure/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/payment-success/index.html
+++ b/composeApp/src/jsMain/resources/payment-success/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/privacy/index.html
+++ b/composeApp/src/jsMain/resources/privacy/index.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-header.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-footer.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-info-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body class="drivebit-static-info-page">
 

--- a/composeApp/src/jsMain/resources/search/abarth/index.html
+++ b/composeApp/src/jsMain/resources/search/abarth/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/audi/index.html
+++ b/composeApp/src/jsMain/resources/search/audi/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/belgee/index.html
+++ b/composeApp/src/jsMain/resources/search/belgee/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/bmw/index.html
+++ b/composeApp/src/jsMain/resources/search/bmw/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/changan/index.html
+++ b/composeApp/src/jsMain/resources/search/changan/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/chery/index.html
+++ b/composeApp/src/jsMain/resources/search/chery/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/chevrolet/index.html
+++ b/composeApp/src/jsMain/resources/search/chevrolet/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/chrysler/index.html
+++ b/composeApp/src/jsMain/resources/search/chrysler/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/dodge/index.html
+++ b/composeApp/src/jsMain/resources/search/dodge/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/evolute/index.html
+++ b/composeApp/src/jsMain/resources/search/evolute/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/exeed/index.html
+++ b/composeApp/src/jsMain/resources/search/exeed/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/faw/index.html
+++ b/composeApp/src/jsMain/resources/search/faw/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/ford/index.html
+++ b/composeApp/src/jsMain/resources/search/ford/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/geely/index.html
+++ b/composeApp/src/jsMain/resources/search/geely/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/genesis/index.html
+++ b/composeApp/src/jsMain/resources/search/genesis/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/geo/index.html
+++ b/composeApp/src/jsMain/resources/search/geo/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/haval/index.html
+++ b/composeApp/src/jsMain/resources/search/haval/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/hyundai/index.html
+++ b/composeApp/src/jsMain/resources/search/hyundai/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/index.html
+++ b/composeApp/src/jsMain/resources/search/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/infiniti/index.html
+++ b/composeApp/src/jsMain/resources/search/infiniti/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/jaecoo/index.html
+++ b/composeApp/src/jsMain/resources/search/jaecoo/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/kia/index.html
+++ b/composeApp/src/jsMain/resources/search/kia/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/lada-vaz/index.html
+++ b/composeApp/src/jsMain/resources/search/lada-vaz/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/lexus/index.html
+++ b/composeApp/src/jsMain/resources/search/lexus/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/maserati/index.html
+++ b/composeApp/src/jsMain/resources/search/maserati/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/mazda/index.html
+++ b/composeApp/src/jsMain/resources/search/mazda/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/mercedes-benz/index.html
+++ b/composeApp/src/jsMain/resources/search/mercedes-benz/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/mitsubishi/index.html
+++ b/composeApp/src/jsMain/resources/search/mitsubishi/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/moskvich/index.html
+++ b/composeApp/src/jsMain/resources/search/moskvich/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/nissan/index.html
+++ b/composeApp/src/jsMain/resources/search/nissan/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/omoda/index.html
+++ b/composeApp/src/jsMain/resources/search/omoda/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/opel/index.html
+++ b/composeApp/src/jsMain/resources/search/opel/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/peugeot/index.html
+++ b/composeApp/src/jsMain/resources/search/peugeot/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/porsche/index.html
+++ b/composeApp/src/jsMain/resources/search/porsche/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/ravon/index.html
+++ b/composeApp/src/jsMain/resources/search/ravon/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/renault/index.html
+++ b/composeApp/src/jsMain/resources/search/renault/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/skoda/index.html
+++ b/composeApp/src/jsMain/resources/search/skoda/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/suzuki/index.html
+++ b/composeApp/src/jsMain/resources/search/suzuki/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/tank/index.html
+++ b/composeApp/src/jsMain/resources/search/tank/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/toyota/index.html
+++ b/composeApp/src/jsMain/resources/search/toyota/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/uaz/index.html
+++ b/composeApp/src/jsMain/resources/search/uaz/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/volkswagen/index.html
+++ b/composeApp/src/jsMain/resources/search/volkswagen/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/volvo/index.html
+++ b/composeApp/src/jsMain/resources/search/volvo/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/search/zeekr/index.html
+++ b/composeApp/src/jsMain/resources/search/zeekr/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-search-page.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/composeApp/src/jsMain/resources/zelenograd/index.html
+++ b/composeApp/src/jsMain/resources/zelenograd/index.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="/vendor/drivebit-seo-text.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-main-promo.css"/>
     <link rel="stylesheet" href="/vendor/drivebit-cars-grid-skeleton.css"/>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/index.html
+++ b/index.html
@@ -572,7 +572,7 @@
         }
     </style>
     <noscript><style>.fallback-content{display:block!important}</style></noscript>
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <body>
     <!-- drivebit-app-header-start -->

--- a/list-your-car.html
+++ b/list-your-car.html
@@ -24,7 +24,7 @@
     <link rel="apple-touch-icon" href="images/logos/turo_logo.svg">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/vendor/fontawesome-free/css/all.min.css">
-    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>
+    <script src="/vendor/drivebit-third-party-deferred.js" defer></script>
 </head>
 <style>
     *, *::before, *::after {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:third-party": "node --test scripts/drivebit-third-party-scheduler.test.mjs",
-    "verify:third-party-loader": "node scripts/verify-third-party-loader.mjs"
+    "verify:third-party-loader": "node scripts/verify-third-party-loader.mjs",
+    "verify:prod-smoke": "node scripts/verify-prod-smoke.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/inject-third-party-loader.mjs
+++ b/scripts/inject-third-party-loader.mjs
@@ -4,38 +4,31 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const MODULE_SCRIPT =
-    '    <script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>';
-const LEGACY_DEFER_SCRIPT =
+const DEFER_SCRIPT =
     '<script src="/vendor/drivebit-third-party-deferred.js" defer></script>';
+const MODULE_SCRIPT =
+    '<script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>';
 
 function walk(dir, out = []) {
     for (const name of fs.readdirSync(dir)) {
         const full = path.join(dir, name);
         const st = fs.statSync(full);
         if (st.isDirectory()) walk(full, out);
-        else if (name === "index.html") out.push(full);
+        else if (name === "index.html" || name.endsWith(".html")) out.push(full);
     }
     return out;
 }
 
-function hasComposeApp(html) {
-    return /composeApp\.js/.test(html);
-}
-
-function hasThirdPartyLoader(html) {
-    return /drivebit-third-party-deferred/.test(html);
-}
-
 function injectLoader(html) {
-    if (html.includes(LEGACY_DEFER_SCRIPT)) {
-        return html.replace(LEGACY_DEFER_SCRIPT, MODULE_SCRIPT.trim());
+    let next = html;
+    if (next.includes(MODULE_SCRIPT)) {
+        next = next.replaceAll(MODULE_SCRIPT, DEFER_SCRIPT);
     }
-    if (hasThirdPartyLoader(html)) {
-        return html;
+    if (next.includes(DEFER_SCRIPT)) {
+        return next;
     }
-    if (html.includes("</head>")) {
-        return html.replace("</head>", `${MODULE_SCRIPT}\n</head>`);
+    if (next.includes("</head>")) {
+        return next.replace("</head>", `    ${DEFER_SCRIPT}\n</head>`);
     }
     throw new Error("no </head> in HTML");
 }
@@ -50,27 +43,22 @@ const extraFiles = [
 const files = [...walk(resources), ...extraFiles].filter((f) => fs.existsSync(f));
 
 let updated = 0;
-let skipped = 0;
-let alreadyPresent = 0;
-
 for (const file of files) {
     let html = fs.readFileSync(file, "utf8");
-    if (!hasComposeApp(html) && !hasThirdPartyLoader(html)) {
-        if (file.endsWith("index.html") && extraFiles.includes(file)) {
-            // auth/car-detail shells may not have composeApp.js in head
-        } else if (!extraFiles.includes(file)) {
-            continue;
-        }
-    }
-    const before = html;
-    html = injectLoader(html);
-    if (html === before) {
-        if (hasThirdPartyLoader(before)) alreadyPresent++;
+    if (!/drivebit-third-party-deferred|composeApp\.js/.test(html) && !extraFiles.includes(file)) {
         continue;
     }
-    fs.writeFileSync(file, html);
-    updated++;
-    console.log("updated:", path.relative(root, file));
+    if (!/drivebit-third-party-deferred|composeApp\.js/.test(html) && extraFiles.includes(file)) {
+        // still try shells
+    }
+    const before = html;
+    if (!/drivebit-third-party-deferred/.test(html) && !/composeApp\.js/.test(html)) continue;
+    html = injectLoader(html);
+    if (html !== before) {
+        fs.writeFileSync(file, html);
+        updated++;
+        console.log("updated:", path.relative(root, file));
+    }
 }
 
-console.log(`done: ${updated} updated, ${alreadyPresent} unchanged, ${skipped} skipped`);
+console.log(`done: ${updated} updated`);

--- a/scripts/verify-prod-smoke.mjs
+++ b/scripts/verify-prod-smoke.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy smoke test for drivebit.ru main functionality.
+ * Usage: node scripts/verify-prod-smoke.mjs [baseUrl]
+ */
+import { chromium } from "playwright";
+
+const base = (process.argv[2] || "https://drivebit.ru").replace(/\/$/, "");
+
+const PAGES = [
+  { path: "/moskva", name: "city landing" },
+  { path: "/search", name: "search" },
+  { path: "/login", name: "login shell" },
+  { path: "/contacts", name: "contacts" },
+  { path: "/list-your-car.html", name: "list your car" },
+];
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+const pageErrors = [];
+page.on("pageerror", (e) => pageErrors.push({ url: page.url(), message: e.message }));
+
+const results = [];
+
+for (const { path, name } of PAGES) {
+  const url = `${base}${path}`;
+  const response = await page.goto(url, { waitUntil: "load", timeout: 60000 });
+  await page.waitForTimeout(path === "/moskva" ? 8000 : 4000);
+
+  const report = await page.evaluate(() => ({
+    hasComposeApp: !!document.querySelector('script[src*="composeApp.js"]'),
+    hasThirdPartyLoader: !!document.querySelector('script[src*="drivebit-third-party-deferred"]'),
+    hasRoot: !!document.getElementById("root"),
+    rootLen: document.getElementById("root")?.innerHTML?.length ?? 0,
+    title: document.title,
+  }));
+
+  results.push({
+    name,
+    path,
+    url,
+    status: response?.status() ?? 0,
+    ...report,
+  });
+}
+
+await page.goto(`${base}/moskva`, { waitUntil: "load", timeout: 60000 });
+await page.waitForTimeout(5000);
+const searchButton = page.getByRole("button", { name: "Найти автомобиль" });
+const searchNavOk = (await searchButton.count()) > 0;
+if (searchNavOk) {
+  await searchButton.click();
+  await page.waitForURL(/\/search/, { timeout: 15000 });
+}
+const navigationOk = /\/search/.test(page.url());
+
+await page.goto(`${base}/moskva`, { waitUntil: "load", timeout: 60000 });
+await page.waitForTimeout(12000);
+const thirdParty = await page.evaluate(() => {
+  const resources = performance.getEntriesByType("resource");
+  const metrika = resources.find((r) => /mc\.yandex\.ru\/metrika\/tag\.js/.test(r.name));
+  const callibri = resources.find((r) => /callibri/.test(r.name));
+  const hasYm = typeof window.ym === "function";
+  const metrikaInDom = Array.from(document.scripts).some((s) => /metrika\/tag\.js/.test(s.src));
+  const callibriInDom = Array.from(document.scripts).some((s) => /callibri/.test(s.src));
+  return {
+    hasYm,
+    metrikaInDom,
+    callibriInDom,
+    metrikaStart: metrika?.startTime ?? null,
+    callibriStart: callibri?.startTime ?? null,
+    metrikaBeforeCallibri:
+      metrika && callibri ? metrika.startTime <= callibri.startTime : metrikaInDom && !callibriInDom,
+  };
+});
+
+const failures = [];
+
+for (const item of results) {
+  if (item.status !== 200) failures.push(`${item.name}: HTTP ${item.status}`);
+  if (!item.hasThirdPartyLoader) failures.push(`${item.name}: missing third-party loader`);
+  if (item.path !== "/list-your-car.html" && !item.hasComposeApp && item.name !== "list your car") {
+    if (!item.hasComposeApp) failures.push(`${item.name}: missing composeApp.js`);
+  }
+  if (item.name === "city landing" || item.name === "search") {
+    if (!item.hasRoot || item.rootLen <= 0) failures.push(`${item.name}: compose root empty`);
+  }
+}
+
+if (!navigationOk) failures.push("navigation: hero search button did not open /search");
+
+const vendorScheduler = await fetch(`${base}/vendor/drivebit-third-party-scheduler.mjs`).then(
+  (r) => r.ok,
+).catch(() => false);
+if (!vendorScheduler) failures.push("vendor: drivebit-third-party-scheduler.mjs not served");
+
+const analytics = {
+  ...thirdParty,
+  vendorScheduler,
+  note:
+    "Metrika/Callibri may be blocked in headless; verify order manually in browser DevTools if needed.",
+};
+
+for (const err of pageErrors) {
+  failures.push(`js error on ${err.url}: ${err.message}`);
+}
+
+const report = {
+  base,
+  pages: results,
+  navigationOk,
+  analytics,
+  pageErrors,
+  ok: failures.length === 0,
+  failures,
+};
+
+console.log(JSON.stringify(report, null, 2));
+await browser.close();
+process.exit(report.ok ? 0 : 1);

--- a/scripts/verify-third-party-loader.mjs
+++ b/scripts/verify-third-party-loader.mjs
@@ -4,6 +4,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFER_LOADER =
+    '<script src="/vendor/drivebit-third-party-deferred.js" defer></script>';
 const MODULE_LOADER =
     '<script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>';
 
@@ -36,15 +38,22 @@ const failures = [];
 for (const rel of REQUIRED_FILES) {
     const file = path.join(root, rel);
     const html = fs.readFileSync(file, "utf8");
-    if (!html.includes(MODULE_LOADER)) {
-        failures.push(`${rel}: missing module third-party loader`);
+    if (html.includes(MODULE_LOADER)) {
+        failures.push(`${rel}: still uses type=module (broken MIME for .mjs imports)`);
+    }
+    if (!html.includes(DEFER_LOADER)) {
+        failures.push(`${rel}: missing defer third-party loader`);
     }
 }
 
 for (const file of composePages) {
     const html = fs.readFileSync(file, "utf8");
-    if (!html.includes(MODULE_LOADER)) {
-        failures.push(`${path.relative(root, file)}: missing module third-party loader`);
+    const rel = path.relative(root, file);
+    if (html.includes(MODULE_LOADER)) {
+        failures.push(`${rel}: still uses type=module`);
+    }
+    if (!html.includes(DEFER_LOADER)) {
+        failures.push(`${rel}: missing defer third-party loader`);
     }
 }
 
@@ -56,4 +65,4 @@ if (failures.length > 0) {
     process.exit(1);
 }
 
-console.log(`OK: third-party loader present on ${composePages.length} composeApp pages + shells`);
+console.log(`OK: defer third-party loader present on ${composePages.length} composeApp pages + shells`);

--- a/vendor/drivebit-third-party-deferred.js
+++ b/vendor/drivebit-third-party-deferred.js
@@ -1,3 +1,118 @@
-import { bootThirdPartyScripts } from "./drivebit-third-party-scheduler.mjs";
+(function (document, window) {
+    var METRIKA_TAG_URL = "https://mc.yandex.ru/metrika/tag.js?id=105947907";
+    var METRIKA_COUNTER_ID = 105947907;
+    var CALLIBRI_URL = "https://cdn.callibri.ru/callibri.js";
+    var JIVO_URL = "//code.jivo.ru/widget/MWoBzLXYYF";
 
-bootThirdPartyScripts({ document, window });
+    function isMetrikaTagRequested() {
+        for (var j = 0; j < document.scripts.length; j++) {
+            if (
+                document.scripts[j].src &&
+                document.scripts[j].src.indexOf("metrika/tag.js") !== -1
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function loadMetrika(onTagReady) {
+        if (isMetrikaTagRequested()) {
+            if (onTagReady) onTagReady();
+            return;
+        }
+
+        window.ym =
+            window.ym ||
+            function () {
+                (window.ym.a = window.ym.a || []).push(arguments);
+            };
+        window.ym.l = 1 * new Date();
+
+        var tagScript = null;
+        for (var j = 0; j < document.scripts.length; j++) {
+            if (document.scripts[j].src === METRIKA_TAG_URL) {
+                tagScript = document.scripts[j];
+                break;
+            }
+        }
+
+        if (!tagScript) {
+            tagScript = document.createElement("script");
+            var firstScript = document.getElementsByTagName("script")[0];
+            tagScript.async = true;
+            tagScript.src = METRIKA_TAG_URL;
+            if (onTagReady) {
+                tagScript.onload = function () {
+                    onTagReady();
+                };
+            }
+            firstScript.parentNode.insertBefore(tagScript, firstScript);
+        } else if (onTagReady) {
+            onTagReady();
+        }
+
+        window.ym(METRIKA_COUNTER_ID, "init", {
+            ssr: true,
+            webvisor: true,
+            clickmap: true,
+            ecommerce: "dataLayer",
+            accurateTrackBounce: true,
+            trackLinks: true,
+        });
+    }
+
+    function loadCallibri(attempt) {
+        if (document.querySelector("script[data-drivebit-callibri]")) {
+            return;
+        }
+        if (document.querySelector('script[src*="callibri.js"]')) {
+            return;
+        }
+        var script = document.createElement("script");
+        script.src = CALLIBRI_URL;
+        script.type = "text/javascript";
+        script.charset = "utf-8";
+        script.defer = true;
+        script.setAttribute("data-drivebit-callibri", "1");
+        script.onerror = function () {
+            script.remove();
+            if ((attempt || 0) < 1) {
+                window.setTimeout(function () {
+                    loadCallibri((attempt || 0) + 1);
+                }, 3000);
+            }
+        };
+        document.head.appendChild(script);
+    }
+
+    function loadJivo() {
+        var host = window.location.hostname;
+        if (host === "localhost" || host === "127.0.0.1") {
+            return;
+        }
+        if (document.querySelector('script[src*="code.jivo.ru"]')) {
+            return;
+        }
+        var script = document.createElement("script");
+        script.src = JIVO_URL;
+        script.async = true;
+        document.head.appendChild(script);
+    }
+
+    function afterLoad(fn) {
+        if (document.readyState === "complete") {
+            fn();
+            return;
+        }
+        window.addEventListener("load", fn, { once: true });
+    }
+
+    loadMetrika(function () {
+        loadCallibri(0);
+    });
+
+    afterLoad(function () {
+        loadJivo();
+    });
+})(document, window);

--- a/vendor/drivebit-third-party-scheduler.mjs
+++ b/vendor/drivebit-third-party-scheduler.mjs
@@ -64,6 +64,9 @@ export function loadCallibri(env, attempt) {
     if (document.querySelector("script[data-drivebit-callibri]")) {
         return;
     }
+    if (document.querySelector('script[src*="callibri.js"]')) {
+        return;
+    }
     const script = document.createElement("script");
     script.src = CALLIBRI_URL;
     script.type = "text/javascript";


### PR DESCRIPTION
## Summary
- Корневая причина: `drivebit-third-party-scheduler.mjs` отдавался как `application/octet-stream`, браузер не исполнял ES-module — Метрика и Callibri не загружались
- Loader снова classic JS с `defer` (без `type=module`)
- Callibri по-прежнему с `defer` и только после `onload` Метрики
- Добавлен `npm run verify:prod-smoke`

## Test plan
- [x] `npm run test:third-party`
- [x] `npm run verify:third-party-loader`
- [ ] После деплоя: в Elements/Network есть `cdn.callibri.ru/callibri.js`
- [ ] `npm run verify:prod-smoke`


Made with [Cursor](https://cursor.com)