### PR TITLE
fix(web): Callibri по официальной документации

### DIFF
--- a/authApp/src/jsMain/resources/auth-app-shell/index.html
+++ b/authApp/src/jsMain/resources/auth-app-shell/index.html
@@ -58,5 +58,7 @@
     </div>
 
     <script type="application/javascript" src="/auth.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/carDetailApp/src/jsMain/resources/car-detail/index.html
+++ b/carDetailApp/src/jsMain/resources/car-detail/index.html
@@ -73,5 +73,7 @@
 
         <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/carDetail.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/contacts/index.html
+++ b/composeApp/src/jsMain/resources/contacts/index.html
@@ -94,5 +94,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/cookies/index.html
+++ b/composeApp/src/jsMain/resources/cookies/index.html
@@ -101,5 +101,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/kaliningrad/index.html
+++ b/composeApp/src/jsMain/resources/kaliningrad/index.html
@@ -264,5 +264,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/krasnogorsk/index.html
+++ b/composeApp/src/jsMain/resources/krasnogorsk/index.html
@@ -264,5 +264,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/lyubertsy/index.html
+++ b/composeApp/src/jsMain/resources/lyubertsy/index.html
@@ -264,5 +264,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-biznes-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-biznes-klassa-bez-voditelya/index.html
@@ -226,5 +226,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html
@@ -271,5 +271,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-komfort-klassa-bez-voditelya/index.html
@@ -226,5 +226,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-premium-klassa-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-premium-klassa-bez-voditelya/index.html
@@ -283,5 +283,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-abkhaziyu/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-abkhaziyu/index.html
@@ -273,5 +273,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-belarus/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-belarus/index.html
@@ -273,5 +273,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-avto-v-krym/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-avto-v-krym/index.html
@@ -293,5 +293,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-minivena-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-minivena-bez-voditelya/index.html
@@ -309,5 +309,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html
+++ b/composeApp/src/jsMain/resources/moskva/arenda-vnedorozhnika-bez-voditelya/index.html
@@ -344,5 +344,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/index.html
+++ b/composeApp/src/jsMain/resources/moskva/index.html
@@ -264,5 +264,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/moskva/poblizosti/index.html
+++ b/composeApp/src/jsMain/resources/moskva/poblizosti/index.html
@@ -300,5 +300,7 @@
     <script src="/vendor/drivebit-leaflet-loader.js" defer></script>
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>    <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/offer/index.html
+++ b/composeApp/src/jsMain/resources/offer/index.html
@@ -486,5 +486,7 @@
     </div>
     <script type="application/javascript" src="/composeApp.js?v=4"></script>
 
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/payment-failure/index.html
+++ b/composeApp/src/jsMain/resources/payment-failure/index.html
@@ -84,5 +84,7 @@
         })();
     </script>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/payment-success/index.html
+++ b/composeApp/src/jsMain/resources/payment-success/index.html
@@ -73,5 +73,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/privacy/index.html
+++ b/composeApp/src/jsMain/resources/privacy/index.html
@@ -143,5 +143,7 @@
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
 
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/abarth/index.html
+++ b/composeApp/src/jsMain/resources/search/abarth/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/audi/index.html
+++ b/composeApp/src/jsMain/resources/search/audi/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/belgee/index.html
+++ b/composeApp/src/jsMain/resources/search/belgee/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/bmw/index.html
+++ b/composeApp/src/jsMain/resources/search/bmw/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/changan/index.html
+++ b/composeApp/src/jsMain/resources/search/changan/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/chery/index.html
+++ b/composeApp/src/jsMain/resources/search/chery/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/chevrolet/index.html
+++ b/composeApp/src/jsMain/resources/search/chevrolet/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/chrysler/index.html
+++ b/composeApp/src/jsMain/resources/search/chrysler/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/dodge/index.html
+++ b/composeApp/src/jsMain/resources/search/dodge/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/evolute/index.html
+++ b/composeApp/src/jsMain/resources/search/evolute/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/exeed/index.html
+++ b/composeApp/src/jsMain/resources/search/exeed/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/faw/index.html
+++ b/composeApp/src/jsMain/resources/search/faw/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/ford/index.html
+++ b/composeApp/src/jsMain/resources/search/ford/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/geely/index.html
+++ b/composeApp/src/jsMain/resources/search/geely/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/genesis/index.html
+++ b/composeApp/src/jsMain/resources/search/genesis/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/geo/index.html
+++ b/composeApp/src/jsMain/resources/search/geo/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/haval/index.html
+++ b/composeApp/src/jsMain/resources/search/haval/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/hyundai/index.html
+++ b/composeApp/src/jsMain/resources/search/hyundai/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/index.html
+++ b/composeApp/src/jsMain/resources/search/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/infiniti/index.html
+++ b/composeApp/src/jsMain/resources/search/infiniti/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/jaecoo/index.html
+++ b/composeApp/src/jsMain/resources/search/jaecoo/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/kia/index.html
+++ b/composeApp/src/jsMain/resources/search/kia/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/lada-vaz/index.html
+++ b/composeApp/src/jsMain/resources/search/lada-vaz/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/lexus/index.html
+++ b/composeApp/src/jsMain/resources/search/lexus/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/maserati/index.html
+++ b/composeApp/src/jsMain/resources/search/maserati/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/mazda/index.html
+++ b/composeApp/src/jsMain/resources/search/mazda/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/mercedes-benz/index.html
+++ b/composeApp/src/jsMain/resources/search/mercedes-benz/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/mitsubishi/index.html
+++ b/composeApp/src/jsMain/resources/search/mitsubishi/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/moskvich/index.html
+++ b/composeApp/src/jsMain/resources/search/moskvich/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/nissan/index.html
+++ b/composeApp/src/jsMain/resources/search/nissan/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/omoda/index.html
+++ b/composeApp/src/jsMain/resources/search/omoda/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/opel/index.html
+++ b/composeApp/src/jsMain/resources/search/opel/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/peugeot/index.html
+++ b/composeApp/src/jsMain/resources/search/peugeot/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/porsche/index.html
+++ b/composeApp/src/jsMain/resources/search/porsche/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/ravon/index.html
+++ b/composeApp/src/jsMain/resources/search/ravon/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/renault/index.html
+++ b/composeApp/src/jsMain/resources/search/renault/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/skoda/index.html
+++ b/composeApp/src/jsMain/resources/search/skoda/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/suzuki/index.html
+++ b/composeApp/src/jsMain/resources/search/suzuki/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/tank/index.html
+++ b/composeApp/src/jsMain/resources/search/tank/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/toyota/index.html
+++ b/composeApp/src/jsMain/resources/search/toyota/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/uaz/index.html
+++ b/composeApp/src/jsMain/resources/search/uaz/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/volkswagen/index.html
+++ b/composeApp/src/jsMain/resources/search/volkswagen/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/volvo/index.html
+++ b/composeApp/src/jsMain/resources/search/volvo/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/search/zeekr/index.html
+++ b/composeApp/src/jsMain/resources/search/zeekr/index.html
@@ -163,5 +163,7 @@
         </footer>
     </div>
         <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/composeApp/src/jsMain/resources/zelenograd/index.html
+++ b/composeApp/src/jsMain/resources/zelenograd/index.html
@@ -264,5 +264,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -967,5 +967,7 @@
     <script type="application/javascript" src="/composeApp.js?v=4" defer></script>
     <script src="/vendor/drivebit-hero-search.js" defer></script>
     <script src="/vendor/drivebit-filters.js" defer></script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/list-your-car.html
+++ b/list-your-car.html
@@ -2306,5 +2306,7 @@ button[disabled] {
         button.addEventListener('click', handleCtaClick);
     });
 </script>
+    <!-- Callibri: official snippet before </body> -->
+    <script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>
 </body>
 </html>

--- a/scripts/drivebit-third-party-scheduler.test.mjs
+++ b/scripts/drivebit-third-party-scheduler.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { bootThirdPartyScripts } from "../vendor/drivebit-third-party-scheduler.mjs";
+import {
+    bootThirdPartyScripts,
+    verifyCallibriInstalled,
+} from "../vendor/drivebit-third-party-scheduler.mjs";
 
 const METRIKA_URL = "https://mc.yandex.ru/metrika/tag.js?id=105947907";
 const CALLIBRI_URL = "https://cdn.callibri.ru/callibri.js";
@@ -16,10 +19,12 @@ function createMockEnv(options = {}) {
 
     const head = {
         appendChild(node) {
+            node.parentNode = head;
             headChildren.push(node);
             scripts.push(node);
         },
         insertBefore(node, ref) {
+            node.parentNode = head;
             headChildren.push(node);
             scripts.push(node);
         },
@@ -40,6 +45,9 @@ function createMockEnv(options = {}) {
         querySelector(selector) {
             if (selector === "script[data-drivebit-callibri]") {
                 return scripts.find((s) => s.getAttribute?.("data-drivebit-callibri") === "1") ?? null;
+            }
+            if (selector === 'script[src*="callibri.js"]') {
+                return scripts.find((s) => s.src?.includes("callibri.js")) ?? null;
             }
             if (selector === 'script[src*="code.jivo.ru"]') {
                 return scripts.find((s) => s.src?.includes("code.jivo.ru")) ?? null;
@@ -85,6 +93,10 @@ function createMockEnv(options = {}) {
     const window = {
         location: { hostname: options.hostname ?? "drivebit.ru" },
         ym: undefined,
+        console: {
+            log() {},
+            warn() {},
+        },
         addEventListener(type, fn, opts) {
             if (type === "load") {
                 loadListeners.push(fn);
@@ -192,4 +204,51 @@ test("bootThirdPartyScripts is idempotent for Metrika and Callibri", () => {
         env.document.scripts.filter((s) => s.getAttribute?.("data-drivebit-callibri") === "1").length,
         callibriCount,
     );
+});
+
+test("verifyCallibriInstalled passes official Callibri check callibriInit → undefined", () => {
+    const logs = [];
+    const env = createMockEnv();
+    env.window.console = {
+        log: (...args) => logs.push(args.join(" ")),
+        warn: (...args) => logs.push("WARN " + args.join(" ")),
+    };
+    env.window.callibriInit = () => undefined;
+
+    assert.equal(verifyCallibriInstalled(env, 0), true);
+    assert.ok(
+        logs.some((line) => line.includes("callibriInit() → undefined")),
+        "Must log official Callibri success check",
+    );
+});
+
+test("verifyCallibriInstalled fails when callibriInit is missing after retries exhausted", () => {
+    const logs = [];
+    const env = createMockEnv();
+    env.window.console = {
+        log: (...args) => logs.push(args.join(" ")),
+        warn: (...args) => logs.push("WARN " + args.join(" ")),
+    };
+
+    assert.equal(verifyCallibriInstalled(env, 40), false);
+    assert.ok(logs.some((line) => line.includes("НЕ обнаружен")));
+});
+
+test("loadCallibri does not duplicate when static docs tag already in DOM", () => {
+    const env = createMockEnv();
+    const staticTag = env.document.createElement("script");
+    staticTag.src = "//cdn.callibri.ru/callibri.js";
+    staticTag.defer = true;
+    staticTag.type = "text/javascript";
+    staticTag.charset = "utf-8";
+    env.document.head.appendChild(staticTag);
+    env.window.callibriInit = () => undefined;
+
+    bootThirdPartyScripts(env);
+    env.metrikaScript()?.onload?.();
+
+    const callibriCount = env.document.scripts.filter((s) =>
+        String(s.src || "").includes("callibri.js"),
+    ).length;
+    assert.equal(callibriCount, 1, "Must not inject a second Callibri script");
 });

--- a/scripts/inject-third-party-loader.mjs
+++ b/scripts/inject-third-party-loader.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+/**
+ * Injects third-party scripts to match Callibri docs:
+ * https://callibri.ru/help/ustanovka_skripta_callibri/kak_ustanovit_skript_callibri_napryamuyu_v_kod_sayta
+ *
+ * - Metrika loader in <head> (defer) — starts immediately, no setTimeout delay
+ * - Callibri exact snippet before </body> with defer (visible in View Source)
+ */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +15,12 @@ const DEFER_SCRIPT =
     '<script src="/vendor/drivebit-third-party-deferred.js" defer></script>';
 const MODULE_SCRIPT =
     '<script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>';
+/** Exact snippet from Callibri documentation */
+const CALLIBRI_SCRIPT =
+    '<script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>';
+
+const CALLIBRI_ANY =
+    /[ \t]*<script[^>]*cdn\.callibri\.ru\/callibri\.js[^>]*>\s*<\/script>\s*/gi;
 
 function walk(dir, out = []) {
     for (const name of fs.readdirSync(dir)) {
@@ -19,18 +32,35 @@ function walk(dir, out = []) {
     return out;
 }
 
-function injectLoader(html) {
+function injectScripts(html) {
     let next = html;
+
     if (next.includes(MODULE_SCRIPT)) {
         next = next.replaceAll(MODULE_SCRIPT, DEFER_SCRIPT);
     }
-    if (next.includes(DEFER_SCRIPT)) {
-        return next;
+
+    // Metrika loader must stay in <head> so it runs before body Callibri (defer order)
+    if (!next.includes(DEFER_SCRIPT)) {
+        if (!next.includes("</head>")) {
+            throw new Error("no </head> in HTML");
+        }
+        next = next.replace("</head>", `    ${DEFER_SCRIPT}\n</head>`);
     }
-    if (next.includes("</head>")) {
-        return next.replace("</head>", `    ${DEFER_SCRIPT}\n</head>`);
+
+    // Remove any existing Callibri tags (head or elsewhere) — re-place before </body>
+    next = next.replace(CALLIBRI_ANY, "");
+
+    if (!next.includes("</body>")) {
+        throw new Error("no </body> in HTML");
     }
-    throw new Error("no </head> in HTML");
+
+    // Docs: add script before closing </body>
+    next = next.replace(
+        "</body>",
+        `    <!-- Callibri: official snippet before </body> -->\n    ${CALLIBRI_SCRIPT}\n</body>`,
+    );
+
+    return next;
 }
 
 const resources = path.join(root, "composeApp/src/jsMain/resources");
@@ -40,7 +70,9 @@ const extraFiles = [
     path.join(root, "authApp/src/jsMain/resources/auth-app-shell/index.html"),
     path.join(root, "carDetailApp/src/jsMain/resources/car-detail/index.html"),
 ];
-const files = [...walk(resources), ...extraFiles].filter((f) => fs.existsSync(f));
+const files = [...new Set([...walk(resources), ...extraFiles])].filter((f) =>
+    fs.existsSync(f),
+);
 
 let updated = 0;
 for (const file of files) {
@@ -48,12 +80,9 @@ for (const file of files) {
     if (!/drivebit-third-party-deferred|composeApp\.js/.test(html) && !extraFiles.includes(file)) {
         continue;
     }
-    if (!/drivebit-third-party-deferred|composeApp\.js/.test(html) && extraFiles.includes(file)) {
-        // still try shells
-    }
-    const before = html;
     if (!/drivebit-third-party-deferred/.test(html) && !/composeApp\.js/.test(html)) continue;
-    html = injectLoader(html);
+    const before = html;
+    html = injectScripts(html);
     if (html !== before) {
         fs.writeFileSync(file, html);
         updated++;

--- a/scripts/verify-third-party-loader.mjs
+++ b/scripts/verify-third-party-loader.mjs
@@ -8,6 +8,9 @@ const DEFER_LOADER =
     '<script src="/vendor/drivebit-third-party-deferred.js" defer></script>';
 const MODULE_LOADER =
     '<script type="module" src="/vendor/drivebit-third-party-deferred.js"></script>';
+/** Exact snippet from Callibri documentation */
+const CALLIBRI_SCRIPT =
+    '<script src="//cdn.callibri.ru/callibri.js" type="text/javascript" charset="utf-8" defer></script>';
 
 const REQUIRED_FILES = [
     "composeApp/src/jsMain/resources/moskva/index.html",
@@ -35,34 +38,51 @@ const composePages = walk(resources).filter((file) => {
 
 const failures = [];
 
-for (const rel of REQUIRED_FILES) {
-    const file = path.join(root, rel);
-    const html = fs.readFileSync(file, "utf8");
-    if (html.includes(MODULE_LOADER)) {
-        failures.push(`${rel}: still uses type=module (broken MIME for .mjs imports)`);
-    }
-    if (!html.includes(DEFER_LOADER)) {
-        failures.push(`${rel}: missing defer third-party loader`);
-    }
-}
-
-for (const file of composePages) {
-    const html = fs.readFileSync(file, "utf8");
-    const rel = path.relative(root, file);
+function checkHtml(rel, html) {
     if (html.includes(MODULE_LOADER)) {
         failures.push(`${rel}: still uses type=module`);
     }
     if (!html.includes(DEFER_LOADER)) {
-        failures.push(`${rel}: missing defer third-party loader`);
+        failures.push(`${rel}: missing defer Metrika loader in head`);
+    }
+    if (!html.includes(CALLIBRI_SCRIPT)) {
+        failures.push(`${rel}: missing exact Callibri docs snippet`);
+    }
+    const callibriIdx = html.indexOf(CALLIBRI_SCRIPT);
+    const bodyIdx = html.lastIndexOf("</body>");
+    if (callibriIdx >= 0 && bodyIdx >= 0 && callibriIdx > bodyIdx) {
+        failures.push(`${rel}: Callibri must be before </body>`);
+    }
+    if (callibriIdx >= 0 && bodyIdx >= 0) {
+        const between = html.slice(callibriIdx, bodyIdx);
+        // Callibri should be near end of body (before </body>), not buried in head only
+        const headEnd = html.indexOf("</head>");
+        if (headEnd >= 0 && callibriIdx < headEnd) {
+            failures.push(`${rel}: Callibri must be before </body>, not in <head> (docs)`);
+        }
+    }
+    const count = (html.match(/cdn\.callibri\.ru\/callibri\.js/g) || []).length;
+    if (count !== 1) {
+        failures.push(`${rel}: expected exactly 1 Callibri script, found ${count}`);
     }
 }
 
+for (const rel of REQUIRED_FILES) {
+    checkHtml(rel, fs.readFileSync(path.join(root, rel), "utf8"));
+}
+
+for (const file of composePages) {
+    checkHtml(path.relative(root, file), fs.readFileSync(file, "utf8"));
+}
+
 if (failures.length > 0) {
-    console.error("Third-party loader verification failed:");
+    console.error("Callibri/docs verification failed:");
     for (const failure of failures) {
         console.error(`  - ${failure}`);
     }
     process.exit(1);
 }
 
-console.log(`OK: defer third-party loader present on ${composePages.length} composeApp pages + shells`);
+console.log(
+    `OK: Metrika loader + Callibri docs snippet before </body> on ${composePages.length} composeApp pages + shells`,
+);

--- a/vendor/drivebit-third-party-deferred.js
+++ b/vendor/drivebit-third-party-deferred.js
@@ -1,8 +1,25 @@
 (function (document, window) {
     var METRIKA_TAG_URL = "https://mc.yandex.ru/metrika/tag.js?id=105947907";
     var METRIKA_COUNTER_ID = 105947907;
-    var CALLIBRI_URL = "https://cdn.callibri.ru/callibri.js";
+    var CALLIBRI_URL = "//cdn.callibri.ru/callibri.js";
     var JIVO_URL = "//code.jivo.ru/widget/MWoBzLXYYF";
+    var LOG_PREFIX = "[DriveBit/Callibri]";
+
+    function log() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(LOG_PREFIX);
+        if (window.console && typeof window.console.log === "function") {
+            window.console.log.apply(window.console, args);
+        }
+    }
+
+    function warn() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(LOG_PREFIX);
+        if (window.console && typeof window.console.warn === "function") {
+            window.console.warn.apply(window.console, args);
+        }
+    }
 
     function isMetrikaTagRequested() {
         for (var j = 0; j < document.scripts.length; j++) {
@@ -16,8 +33,67 @@
         return false;
     }
 
+    function findCallibriScript() {
+        return (
+            document.querySelector("script[data-drivebit-callibri]") ||
+            document.querySelector('script[src*="callibri.js"]')
+        );
+    }
+
+    /**
+     * Official Callibri check:
+     * https://callibri.ru/help/ustanovka_skripta_callibri/kak_ustanovit_skript_callibri_napryamuyu_v_kod_sayta
+     * Console → callibriInit() → undefined means script is installed.
+     */
+    function verifyCallibriInstalled(attempt) {
+        var n = attempt || 0;
+        if (typeof window.callibriInit === "function") {
+            var result;
+            try {
+                result = window.callibriInit();
+            } catch (e) {
+                warn("callibriInit() threw:", e && e.message ? e.message : e);
+                return false;
+            }
+            if (result === undefined) {
+                var tag = findCallibriScript();
+                log(
+                    "OK: Callibri установлен (docs: callibriInit() → undefined)",
+                );
+                log(
+                    "HTML/DOM script:",
+                    tag && tag.src ? tag.src : "(не найден)",
+                    tag && tag.defer ? "defer=true" : "",
+                );
+                if (typeof window.ym === "function") {
+                    try {
+                        window.ym(METRIKA_COUNTER_ID, "getClientID", function (clientId) {
+                            log("Yandex Metrika ClientID:", clientId || "(пусто)");
+                        });
+                    } catch (e) {
+                        warn("getClientID failed:", e && e.message ? e.message : e);
+                    }
+                }
+                return true;
+            }
+            warn("callibriInit() unexpected result:", result);
+            return false;
+        }
+        if (n < 40) {
+            window.setTimeout(function () {
+                verifyCallibriInstalled(n + 1);
+            }, 250);
+            return null;
+        }
+        warn(
+            "Callibri НЕ обнаружен: нет callibriInit. Смотрите View Source → </body> и Network → callibri.js",
+        );
+        return false;
+    }
+
     function loadMetrika(onTagReady) {
         if (isMetrikaTagRequested()) {
+            log("Metrika tag.js already present");
             if (onTagReady) onTagReady();
             return;
         }
@@ -44,10 +120,12 @@
             tagScript.src = METRIKA_TAG_URL;
             if (onTagReady) {
                 tagScript.onload = function () {
+                    log("Metrika tag.js loaded (before Callibri defer runs)");
                     onTagReady();
                 };
             }
             firstScript.parentNode.insertBefore(tagScript, firstScript);
+            log("Metrika: start tag.js immediately (no setTimeout/idle delay)");
         } else if (onTagReady) {
             onTagReady();
         }
@@ -62,24 +140,37 @@
         });
     }
 
-    function loadCallibri(attempt) {
-        if (document.querySelector("script[data-drivebit-callibri]")) {
+    /**
+     * Prefer static Callibri tag from HTML (docs). Dynamic insert is fallback only.
+     */
+    function ensureCallibri(attempt) {
+        var existing = findCallibriScript();
+        if (existing) {
+            log(
+                "Callibri static/docs tag found in DOM:",
+                existing.src || "(inline)",
+                existing.defer ? "defer=true" : "",
+            );
+            verifyCallibriInstalled(0);
             return;
         }
-        if (document.querySelector('script[src*="callibri.js"]')) {
-            return;
-        }
+        warn("Static Callibri tag missing — fallback dynamic insert (docs prefer static before </body>)");
         var script = document.createElement("script");
         script.src = CALLIBRI_URL;
         script.type = "text/javascript";
         script.charset = "utf-8";
         script.defer = true;
         script.setAttribute("data-drivebit-callibri", "1");
+        script.onload = function () {
+            log("Callibri fallback loaded");
+            verifyCallibriInstalled(0);
+        };
         script.onerror = function () {
             script.remove();
+            warn("callibri.js load error, attempt=", attempt || 0);
             if ((attempt || 0) < 1) {
                 window.setTimeout(function () {
-                    loadCallibri((attempt || 0) + 1);
+                    ensureCallibri((attempt || 0) + 1);
                 }, 3000);
             }
         };
@@ -108,8 +199,9 @@
         window.addEventListener("load", fn, { once: true });
     }
 
+    log("boot: Metrika first, then verify Callibri (docs snippet before </body>)");
     loadMetrika(function () {
-        loadCallibri(0);
+        ensureCallibri(0);
     });
 
     afterLoad(function () {

--- a/vendor/drivebit-third-party-scheduler.mjs
+++ b/vendor/drivebit-third-party-scheduler.mjs
@@ -1,7 +1,26 @@
 const METRIKA_TAG_URL = "https://mc.yandex.ru/metrika/tag.js?id=105947907";
 const METRIKA_COUNTER_ID = 105947907;
-const CALLIBRI_URL = "https://cdn.callibri.ru/callibri.js";
+const CALLIBRI_URL = "//cdn.callibri.ru/callibri.js";
 const JIVO_URL = "//code.jivo.ru/widget/MWoBzLXYYF";
+const LOG_PREFIX = "[DriveBit/Callibri]";
+
+function log(env) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    args.unshift(LOG_PREFIX);
+    const c = env.window && env.window.console;
+    if (c && typeof c.log === "function") {
+        c.log.apply(c, args);
+    }
+}
+
+function warn(env) {
+    const args = Array.prototype.slice.call(arguments, 1);
+    args.unshift(LOG_PREFIX);
+    const c = env.window && env.window.console;
+    if (c && typeof c.warn === "function") {
+        c.warn.apply(c, args);
+    }
+}
 
 function isMetrikaTagRequested(document) {
     for (let j = 0; j < document.scripts.length; j++) {
@@ -9,6 +28,45 @@ function isMetrikaTagRequested(document) {
             return true;
         }
     }
+    return false;
+}
+
+function findCallibriScript(document) {
+    return (
+        document.querySelector("script[data-drivebit-callibri]") ||
+        document.querySelector('script[src*="callibri.js"]')
+    );
+}
+
+/**
+ * Official Callibri install check from docs: callibriInit() → undefined
+ * @see https://callibri.ru/help/ustanovka_skripta_callibri/kak_ustanovit_skript_callibri_napryamuyu_v_kod_sayta
+ */
+export function verifyCallibriInstalled(env, attempt) {
+    const { window } = env;
+    const n = attempt || 0;
+    if (typeof window.callibriInit === "function") {
+        let result;
+        try {
+            result = window.callibriInit();
+        } catch (e) {
+            warn(env, "callibriInit() threw:", e && e.message ? e.message : e);
+            return false;
+        }
+        if (result === undefined) {
+            log(env, "OK: Callibri установлен (docs: callibriInit() → undefined)");
+            return true;
+        }
+        warn(env, "callibriInit() unexpected result:", result);
+        return false;
+    }
+    if (n < 40) {
+        window.setTimeout(function () {
+            verifyCallibriInstalled(env, n + 1);
+        }, 250);
+        return null;
+    }
+    warn(env, "Callibri НЕ обнаружен: нет callibriInit");
     return false;
 }
 
@@ -45,6 +103,7 @@ export function loadMetrika(env, onTagReady) {
             };
         }
         firstScript.parentNode.insertBefore(tagScript, firstScript);
+        log(env, "Metrika: start tag.js immediately (no setTimeout/idle delay)");
     } else if (onTagReady) {
         onTagReady();
     }
@@ -59,20 +118,25 @@ export function loadMetrika(env, onTagReady) {
     });
 }
 
+/** Prefer static docs tag; dynamic insert is fallback only. */
 export function loadCallibri(env, attempt) {
     const { document, window } = env;
-    if (document.querySelector("script[data-drivebit-callibri]")) {
+    const existing = findCallibriScript(document);
+    if (existing) {
+        log(env, "Callibri static/docs tag found in DOM:", existing.src || "(inline)");
+        verifyCallibriInstalled(env, 0);
         return;
     }
-    if (document.querySelector('script[src*="callibri.js"]')) {
-        return;
-    }
+    warn(env, "Static Callibri tag missing — fallback dynamic insert");
     const script = document.createElement("script");
     script.src = CALLIBRI_URL;
     script.type = "text/javascript";
     script.charset = "utf-8";
     script.defer = true;
     script.setAttribute("data-drivebit-callibri", "1");
+    script.onload = function () {
+        verifyCallibriInstalled(env, 0);
+    };
     script.onerror = function () {
         script.remove();
         if ((attempt || 0) < 1) {
@@ -108,6 +172,7 @@ function afterLoad(env, fn) {
 }
 
 export function bootThirdPartyScripts(env) {
+    log(env, "boot: Metrika first, then verify Callibri (docs snippet before </body>)");
     loadMetrika(env, function () {
         loadCallibri(env, 0);
     });


### PR DESCRIPTION
## Summary
- Добавлен точный snippet Callibri из docs перед `</body>` (виден в «Просмотре кода»)
- Metrika loader в `<head>` без setTimeout — загружается раньше Callibri (defer order)
- Console-логи с официальной проверкой `callibriInit() → undefined`
- Динамическая вставка Callibri только как fallback

## Test plan
- [x] `npm run test:third-party` — 8/8
- [x] `npm run verify:third-party-loader`
- [ ] После деплоя: View Source → `cdn.callibri.ru/callibri.js` перед `</body>`
- [ ] Console: `[DriveBit/Callibri] OK: Callibri установлен`


Made with [Cursor](https://cursor.com)