### PR TITLE
fix(web): /audi and /bmw no longer redirect to /moskva

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/navigation/NavigationComposable.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/navigation/NavigationComposable.kt
@@ -8,6 +8,7 @@ import my.drivebit.repositories.MyCityRepository
 import my.drivebit.shared.storage.Storage
 import my.drivebit.utils.cityNameToSlug
 import my.drivebit.web.CitySlugResolver
+import my.drivebit.web.isSearchPath
 import my.drivebit.web.parseCitySlugFromPath
 import org.koin.compose.koinInject
 
@@ -27,6 +28,7 @@ fun Navigation(content: @Composable (String) -> Unit) {
                     val target = "/${cityNameToSlug(city.name)}"
                     navigationController?.replacePath(target)
                 }
+                isSearchPath(currentPath) -> Unit
                 else -> {
                     parseCitySlugFromPath(currentPath)?.let { slug ->
                         val city =

--- a/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/CityPathRoutingTest.kt
+++ b/DrivebitWeb/src/jsTest/kotlin/my/drivebit/web/CityPathRoutingTest.kt
@@ -35,6 +35,14 @@ class CityPathRoutingTest {
     }
 
     @Test
+    fun parseCityPath_returnsNullForShortBrandSeoPaths() {
+        assertNull(parseCityPath("/audi"))
+        assertNull(parseCityPath("/bmw"))
+        assertNull(parseCityPath("/audi/"))
+        assertNull(parseCityPath("/BMW"))
+    }
+
+    @Test
     fun parseCityPath_returnsNullForDownloadBookingContract() {
         assertNull(parseCityPath("/download-booking-contract"))
         assertNull(parseCityPath("/download-booking-contract?bookingId=abc"))

--- a/WebShell/src/jsMain/kotlin/my/drivebit/web/CitySlugParsing.kt
+++ b/WebShell/src/jsMain/kotlin/my/drivebit/web/CitySlugParsing.kt
@@ -1,5 +1,7 @@
 package my.drivebit.web
 
+import my.drivebit.utils.SHORT_BRAND_SEARCH_PATH_SLUGS
+
 data class CityPathParts(
     val citySlug: String,
     val filterSlug: String? = null,
@@ -75,7 +77,7 @@ fun parseCityPath(pathname: String): CityPathParts? {
     val segments = trimmed.split('/').filter { it.isNotEmpty() }
     if (segments.size != 1 && segments.size != 2) return null
     val citySlug = segments[0].lowercase()
-    if (citySlug in RESERVED_FIRST_SEGMENTS) return null
+    if (citySlug in RESERVED_FIRST_SEGMENTS || citySlug in SHORT_BRAND_SEARCH_PATH_SLUGS) return null
     val filterSlug = segments.getOrNull(1)?.lowercase()
     return CityPathParts(citySlug = citySlug, filterSlug = filterSlug)
 }


### PR DESCRIPTION
## Summary
- Root cause: `parseCityPath("/audi")` treated Audi as a city slug; unresolved city → fallback redirect to `/moskva`
- Exclude short brand SEO slugs (`audi`, `bmw`) from city parsing
- Skip city-resolution side effects on search/brand paths in `Navigation`

## Test plan
- [x] CityPathRoutingTest: `/audi` and `/bmw` are not city paths
- [x] `:DrivebitWeb:jsBrowserTest`
- [ ] After deploy: open https://drivebit.ru/audi and confirm URL stays `/audi`


Made with [Cursor](https://cursor.com)