### PR TITLE
fix(search): live city IDs and hide search skeleton

### DIFF
--- a/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
+++ b/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
@@ -19,6 +19,7 @@ private data class CarDtoPagedResult(
 private data class CarDtoItem(
     val id: String,
     val general: CarDtoGeneral? = null,
+    val dailyRate: Double? = null,
     val price: Double? = null,
 )
 
@@ -78,7 +79,7 @@ class HttpSearchCarsApi(
                     SearchCarCard(
                         id = item.id,
                         title = listOf(brand, model).filter { it.isNotEmpty() }.joinToString(" ").ifEmpty { item.id },
-                        price = item.price?.takeIf { it > 0 }?.toInt(),
+                        price = (item.dailyRate ?: item.price)?.takeIf { it > 0 }?.toInt(),
                     )
                 },
             totalCount = paged.totalCount,
@@ -89,7 +90,8 @@ class HttpSearchCarsApi(
 
 fun resolveSearchCityId(citySlug: String?): String =
     when (citySlug?.lowercase()) {
-        "kaliningrad" -> "158831"
-        "rostov-na-donu" -> "158832"
-        else -> "158830"
+        "rostov-na-donu" -> "158833"
+        "krasnogorsk" -> "158840"
+        "lyubertsy" -> "158841"
+        else -> "158835"
     }

--- a/SearchCore/src/commonTest/kotlin/my/drivebit/search/ResolveSearchCityIdTest.kt
+++ b/SearchCore/src/commonTest/kotlin/my/drivebit/search/ResolveSearchCityIdTest.kt
@@ -1,0 +1,25 @@
+package my.drivebit.search
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResolveSearchCityIdTest {
+    @Test
+    fun `moskva slug resolves to live Moscow city id used by home search`() {
+        assertEquals("158835", resolveSearchCityId("moskva"))
+        assertEquals("158835", resolveSearchCityId("Moskva"))
+    }
+
+    @Test
+    fun `null or unknown slug defaults to Moscow live city id`() {
+        assertEquals("158835", resolveSearchCityId(null))
+        assertEquals("158835", resolveSearchCityId("unknown-city"))
+    }
+
+    @Test
+    fun `rostov and nearby city slugs resolve to live dictionary ids`() {
+        assertEquals("158833", resolveSearchCityId("rostov-na-donu"))
+        assertEquals("158840", resolveSearchCityId("krasnogorsk"))
+        assertEquals("158841", resolveSearchCityId("lyubertsy"))
+    }
+}

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -38,6 +38,7 @@ fun SearchApp() {
     }
 
     Div({
+        classes("drivebit-cars-grid-mounted")
         style { padding(16.px) }
     }) {
         H1 { Text("Поиск автомобилей") }


### PR DESCRIPTION
## Summary
- Map `moskva`/default to live city id `158835` (was `158830` → empty API results)
- Fix Rostov/Krasnogorsk/Lyubertsy ids; prefer `dailyRate` for card prices
- Add `drivebit-cars-grid-mounted` so static search skeleton hides when SearchApp mounts

## Test plan
- [x] `ResolveSearchCityIdTest` green
- [ ] CI green on this PR
- [ ] pages-dev `/moskva/search` shows cars, no eternal skeleton


Made with [Cursor](https://cursor.com)