### PR TITLE
fix(search): pagination next page reset by date selector

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
@@ -60,8 +60,12 @@ fun SearchDateRangeSelector(
         if (endState.date != endDate) endViewModel.setDate(endDate)
     }
 
-    LaunchedEffect(startState.date) { onStartDateChanged(startState.date) }
-    LaunchedEffect(endState.date) { onEndDateChanged(endState.date) }
+    LaunchedEffect(startState.date) {
+        if (startState.date != startDate) onStartDateChanged(startState.date)
+    }
+    LaunchedEffect(endState.date) {
+        if (endState.date != endDate) onEndDateChanged(endState.date)
+    }
 
     Row(gap = 12.px) {
         SearchDateFieldItem(

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -254,10 +254,14 @@ private fun SearchResultsContent(
             startDate = filters.startDate,
             endDate = filters.endDate,
             onStartDateChanged = { date ->
-                navigateFilter { it.copy(startDate = date) }
+                if (date != filters.startDate) {
+                    navigateFilter { it.copy(startDate = date) }
+                }
             },
             onEndDateChanged = { date ->
-                navigateFilter { it.copy(endDate = date) }
+                if (date != filters.endDate) {
+                    navigateFilter { it.copy(endDate = date) }
+                }
             },
         )
         FlowRow(gap = 8.px) {


### PR DESCRIPTION
## Summary
- SearchDateRangeSelector no longer emits date callbacks when the value is unchanged
- SearchApp ignores no-op date updates so applySearchFilterChange cannot reset page to 1 after «Вперёд»

## Test plan
- [ ] CI green
- [ ] On /moskva/search click «Вперёд» → URL keeps ?page=2 and list advances
- [ ] Date filters still update URL and reset page when dates actually change


Made with [Cursor](https://cursor.com)