### PR TITLE
fix(search): show shimmer while search results load

### DIFF
--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -14,12 +14,12 @@ import my.drivebit.components.Box
 import my.drivebit.components.BoxOverlay
 import my.drivebit.components.BrandModelFilter
 import my.drivebit.components.CarsGrid
+import my.drivebit.components.CarsGridSkeleton
 import my.drivebit.components.Column
 import my.drivebit.components.DriveTypeFilter
 import my.drivebit.components.FilterChip
 import my.drivebit.components.FiltersResetChip
 import my.drivebit.components.FlowRow
-import my.drivebit.components.Loader
 import my.drivebit.components.MileageFilter
 import my.drivebit.components.PaginationBar
 import my.drivebit.components.PriceFilter
@@ -127,7 +127,6 @@ fun SearchApp() {
         )
 
     Div({
-        classes("drivebit-cars-grid-mounted")
         style {
             width(100.percent)
             padding(20.px)
@@ -138,7 +137,7 @@ fun SearchApp() {
         when (val currentState = state) {
             is SearchUiState.Loading -> {
                 SearchPageHeadline(pageHeadline)
-                Loader()
+                CarsGridSkeleton()
             }
 
             is SearchUiState.Error -> {


### PR DESCRIPTION
## Summary
- Show `CarsGridSkeleton` on search Loading instead of `Loader`
- Stop applying `drivebit-cars-grid-mounted` before results arrive so static HTML shimmer stays visible until Compose skeleton/results take over

## Test plan
- [ ] CI green on this PR
- [ ] `/moskva/search` on pages-dev shows shimmer until cars load


Made with [Cursor](https://cursor.com)