### PR TITLE
fix(search): blue calendar icons in date fields

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DateRangeSelector.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DateRangeSelector.kt
@@ -166,7 +166,7 @@ fun DateRangeSelector(
 }
 
 @Composable
-private fun CalendarIconBlue(size: CSSSizeValue<out CSSUnit.px>) {
+fun CalendarIconBlue(size: CSSSizeValue<out CSSUnit.px>) {
     Div({
         style {
             width(size)

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
@@ -33,7 +33,6 @@ import org.jetbrains.compose.web.css.padding
 import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Img
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLElement
@@ -163,18 +162,7 @@ private fun SearchDateFieldItem(
                     }
                 }) { Text(value) }
             }
-            Img(
-                src = "/images/filter-main/calendar.svg",
-                alt = "календарь",
-                attrs = {
-                    style {
-                        width(18.px)
-                        height(18.px)
-                        property("flex-shrink", "0")
-                        property("opacity", "0.55")
-                    }
-                },
-            )
+            CalendarIconBlue(size = 18.px)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace gray faded calendar SVG in search date fields with brand-blue `CalendarIconBlue`
- Reuse the same mask icon as hero/date range selectors

## Test plan
- [ ] CI green
- [ ] `/moskva/search` calendar icons are blue on pages-dev


Made with [Cursor](https://cursor.com)