### PR TITLE
fix(search): mobile layout + shimmer under filter chips

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BodyTypeFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BodyTypeFilter.kt
@@ -34,8 +34,9 @@ fun BodyTypeFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         Span({

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/Box.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/Box.kt
@@ -41,14 +41,18 @@ fun BoxOverlay(content: @Composable () -> Unit) {
             position(Position.Absolute)
             top(0.px)
             left(0.px)
+            width(100.percent)
             property("z-index", "10")
             property("pointer-events", "none")
+            property("box-sizing", "border-box")
         }
     }) {
         Div({
             style {
                 property("pointer-events", "auto")
-                property("display", "inline-block")
+                width(100.percent)
+                property("max-width", "400px")
+                property("box-sizing", "border-box")
             }
         }) {
             content()

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BrandModelFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BrandModelFilter.kt
@@ -49,8 +49,8 @@ fun BrandModelFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
             property("box-sizing", "border-box")
         },
     ) {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DriveTypeFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DriveTypeFilter.kt
@@ -34,8 +34,9 @@ fun DriveTypeFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         Span({

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/MileageFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/MileageFilter.kt
@@ -38,8 +38,9 @@ fun MileageFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         Span({

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/PriceFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/PriceFilter.kt
@@ -35,8 +35,9 @@ fun PriceFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         PriceFilterTitle()

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
@@ -30,6 +30,7 @@ import org.jetbrains.compose.web.css.justifyContent
 import org.jetbrains.compose.web.css.marginBottom
 import org.jetbrains.compose.web.css.minWidth
 import org.jetbrains.compose.web.css.padding
+import org.jetbrains.compose.web.css.percent
 import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.dom.Div
@@ -66,7 +67,14 @@ fun SearchDateRangeSelector(
         if (endState.date != endDate) onEndDateChanged(endState.date)
     }
 
-    Row(gap = 12.px) {
+    Row(
+        gap = 12.px,
+        modifier = {
+            width(100.percent)
+            property("box-sizing", "border-box")
+            property("min-width", "0")
+        },
+    ) {
         SearchDateFieldItem(
             actionLabel = "с",
             value = startState.date?.let(::formatSearchDateForDisplay) ?: "выберите даты",

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SeatsFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SeatsFilter.kt
@@ -28,8 +28,9 @@ fun SeatsFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         Span({

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/YearFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/YearFilter.kt
@@ -44,8 +44,9 @@ fun YearFilter(
             backgroundColor(CSSColors.White)
             borderRadius(12.px)
             property("box-shadow", "0 4px 12px rgba(0, 0, 0, 0.1)")
-            width(400.px)
-            property("max-width", "90vw")
+            width(100.percent)
+            property("max-width", "400px")
+            property("box-sizing", "border-box")
         },
     ) {
         Span({

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -112,17 +112,26 @@ fun SearchApp() {
         viewModel.load(locationHref)
     }
 
-    val filtersForHeadline =
+    var lastFilters by remember { mutableStateOf<SearchFilterSet?>(null) }
+
+    LaunchedEffect(state) {
+        val current = state
+        if (current is SearchUiState.Results) {
+            lastFilters = current.filters
+        }
+    }
+
+    val filtersForUi =
         when (val s = state) {
             is SearchUiState.Results -> s.filters
-            else -> null
+            else -> lastFilters ?: filtersFromLocation(locationHref)
         }
 
     val pathOnly = locationHref.substringBefore('?').substringBefore('#')
     val pageHeadline =
         resolveSearchPageHeadline(
             path = pathOnly,
-            brandName = filtersForHeadline?.brandName,
+            brandName = filtersForUi.brandName,
             cityName = searchCityName,
         )
 
@@ -132,12 +141,17 @@ fun SearchApp() {
             padding(20.px)
             property("max-width", "1200px")
             property("margin", "0 auto")
+            property("box-sizing", "border-box")
         }
     }) {
         when (val currentState = state) {
             is SearchUiState.Loading -> {
-                SearchPageHeadline(pageHeadline)
-                CarsGridSkeleton()
+                SearchResultsContent(
+                    filters = filtersForUi,
+                    result = null,
+                    pageHeadline = pageHeadline,
+                    onLocationChanged = { locationHref = currentLocationHref() },
+                )
             }
 
             is SearchUiState.Error -> {
@@ -147,7 +161,8 @@ fun SearchApp() {
 
             is SearchUiState.Results -> {
                 SearchResultsContent(
-                    state = currentState,
+                    filters = currentState.filters,
+                    result = currentState.result,
                     pageHeadline = pageHeadline,
                     onLocationChanged = { locationHref = currentLocationHref() },
                 )
@@ -156,13 +171,35 @@ fun SearchApp() {
     }
 }
 
+private fun filtersFromLocation(locationHref: String): SearchFilterSet {
+    val parts = parseSearchUrl(locationHref)
+    return SearchFilterSet(
+        citySlug = parts.citySlug,
+        brandSlug = parts.brandSlug,
+        modelSlug = parts.modelSlug,
+        startDate = parts.startDate,
+        endDate = parts.endDate,
+        dailyRateMin = parts.dailyRateMin,
+        dailyRateMax = parts.dailyRateMax,
+        driveType = parts.driveType,
+        driveTypeLabel = parts.driveTypeLabel,
+        bodyType = parts.bodyType,
+        bodyTypeLabel = parts.bodyTypeLabel,
+        seatsMin = parts.seatsMin,
+        yearMin = parts.yearMin,
+        yearMax = parts.yearMax,
+        mileageMin = parts.mileageMin,
+        page = parts.page,
+    )
+}
+
 @Composable
 private fun SearchResultsContent(
-    state: SearchUiState.Results,
+    filters: SearchFilterSet,
+    result: SearchCarsResult?,
     pageHeadline: String,
     onLocationChanged: () -> Unit,
 ) {
-    val filters = state.filters
     var showPriceFilter by remember { mutableStateOf(false) }
     var showBrandFilter by remember { mutableStateOf(false) }
     var showDriveTypeFilter by remember { mutableStateOf(false) }
@@ -383,41 +420,47 @@ private fun SearchResultsContent(
                 property("min-height", "240px")
             },
             underneath = {
-                if (state.result.cars.isNotEmpty()) {
-                    CarsGrid(
-                        cars = state.result.cars,
-                        carHref = { car ->
-                            buildCarDetailUrl(
-                                carId = car.id,
-                                startDate = filters.startDate,
-                                endDate = filters.endDate,
-                            )
-                        },
-                    )
-                    PaginationBar(
-                        currentPage = urlPageToUiIndex(filters.page),
-                        totalPages = state.result.totalPages,
-                        totalCount = state.result.totalCount,
-                        pageSize = 9,
-                        onPageChange = { uiIndex ->
-                            navigatePage(uiIndexToUrlPage(uiIndex))
-                        },
-                    )
-                } else {
-                    Div({
-                        style {
-                            padding(40.px)
-                            textAlign("center")
-                        }
-                    }) {
-                        Span({
+                when {
+                    result == null -> {
+                        CarsGridSkeleton()
+                    }
+                    result.cars.isNotEmpty() -> {
+                        CarsGrid(
+                            cars = result.cars,
+                            carHref = { car ->
+                                buildCarDetailUrl(
+                                    carId = car.id,
+                                    startDate = filters.startDate,
+                                    endDate = filters.endDate,
+                                )
+                            },
+                        )
+                        PaginationBar(
+                            currentPage = urlPageToUiIndex(filters.page),
+                            totalPages = result.totalPages,
+                            totalCount = result.totalCount,
+                            pageSize = 9,
+                            onPageChange = { uiIndex ->
+                                navigatePage(uiIndexToUrlPage(uiIndex))
+                            },
+                        )
+                    }
+                    else -> {
+                        Div({
                             style {
-                                applyTypography(CSSTypography.Styles.body)
-                                fontSize(CSSTypography.FontSize.base)
-                                color(CSSColors.Gray600)
+                                padding(40.px)
+                                textAlign("center")
                             }
                         }) {
-                            Text("Автомобили не найдены")
+                            Span({
+                                style {
+                                    applyTypography(CSSTypography.Styles.body)
+                                    fontSize(CSSTypography.FontSize.base)
+                                    color(CSSColors.Gray600)
+                                }
+                            }) {
+                                Text("Автомобили не найдены")
+                            }
                         }
                     }
                 }
@@ -428,7 +471,7 @@ private fun SearchResultsContent(
                         PriceFilter(
                             minPrice = minPrice,
                             maxPrice = maxPrice,
-                            resultsCount = state.result.totalCount,
+                            resultsCount = result?.totalCount ?: 0,
                             onReset = {
                                 minPrice.value = 0
                                 maxPrice.value = 50000
@@ -533,7 +576,7 @@ private fun SearchResultsContent(
                     BoxOverlay {
                         SeatsFilter(
                             selectedSeatsMin = filters.seatsMin,
-                            resultsCount = state.result.totalCount,
+                            resultsCount = result?.totalCount ?: 0,
                             onSeatsMinSelected = { seatsMin ->
                                 navigateFilter { it.copy(seatsMin = seatsMin) }
                                 showSeatsFilter = false

--- a/vendor/drivebit-search-page.css
+++ b/vendor/drivebit-search-page.css
@@ -30,3 +30,10 @@ body:has(#root:not(:empty)) #drivebit-search-headline-static {
         font-size: 24px;
     }
 }
+
+@media (max-width: 640px) {
+    #root > div {
+        padding-left: 16px !important;
+        padding-right: 16px !important;
+    }
+}


### PR DESCRIPTION
## Summary
- Fix mobile overflow: `box-sizing` on search root, date row width, filter overlays constrained to parent
- Keep headline/dates/filter chips during Loading; show `CarsGridSkeleton` under the chips

## Test plan
- [ ] CI green
- [ ] Mobile `/moskva/search`: dates and Кузов overlay not clipped
- [ ] Filter change shows shimmer under chips, chips stay visible


Made with [Cursor](https://cursor.com)