### PR TITLE
fix(search): brand→model step, date pairs, brand+body search

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BrandModelFilter.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/BrandModelFilter.kt
@@ -25,6 +25,8 @@ fun BrandModelFilter(
     onModelSelected: (modelId: Int, modelName: String) -> Unit,
     onReset: () -> Unit,
     onOk: () -> Unit,
+    initialBrandId: Int? = null,
+    initialBrandName: String? = null,
 ) {
     val brandViewModel: CarBrandViewModel = koinInject()
     val modelViewModel: CarModelViewModel = koinInject()
@@ -33,13 +35,19 @@ fun BrandModelFilter(
     val brandError by brandViewModel.error.collectAsState()
     val modelError by modelViewModel.error.collectAsState()
 
-    var selectedBrandId by remember { mutableStateOf<Int?>(null) }
-    var selectedBrandName by remember { mutableStateOf<String?>(null) }
+    var selectedBrandId by remember { mutableStateOf(initialBrandId) }
+    var selectedBrandName by remember { mutableStateOf(initialBrandName) }
     var brandQuery by remember { mutableStateOf("") }
     var modelQuery by remember { mutableStateOf("") }
 
     LaunchedEffect(Unit) {
         brandViewModel.loadBrands(existingInFleetOnly = true)
+    }
+
+    LaunchedEffect(initialBrandId) {
+        if (initialBrandId != null && selectedBrandId == initialBrandId) {
+            modelViewModel.loadModels(initialBrandId, existingInFleetOnly = true)
+        }
     }
 
     Column(

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/SearchDateRangeSelector.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.number
 import my.drivebit.design.CSSColors
 import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
+import my.drivebit.utils.resolveSearchDateRangeNavigation
 import my.drivebit.viewmodels.DateFieldViewModel
 import org.jetbrains.compose.web.css.AlignItems
 import org.jetbrains.compose.web.css.DisplayStyle
@@ -25,7 +26,6 @@ import org.jetbrains.compose.web.css.flex
 import org.jetbrains.compose.web.css.fontSize
 import org.jetbrains.compose.web.css.fontWeight
 import org.jetbrains.compose.web.css.gap
-import org.jetbrains.compose.web.css.height
 import org.jetbrains.compose.web.css.justifyContent
 import org.jetbrains.compose.web.css.marginBottom
 import org.jetbrains.compose.web.css.minWidth
@@ -42,11 +42,11 @@ import org.w3c.dom.HTMLElement
 fun SearchDateRangeSelector(
     startDate: String?,
     endDate: String?,
-    onStartDateChanged: (String?) -> Unit,
-    onEndDateChanged: (String?) -> Unit,
+    onDateRangeChanged: (start: String?, end: String?) -> Unit,
     disabledDates: Set<String> = emptySet(),
     endMinOffsetDaysFromStart: Int = 0,
     clearRangeOnCancel: Boolean = true,
+    applyOnlyCompleteRange: Boolean = false,
 ) {
     val startViewModel = remember { DateFieldViewModel(initialDate = startDate) }
     val endViewModel = remember { DateFieldViewModel(initialDate = endDate) }
@@ -60,11 +60,23 @@ fun SearchDateRangeSelector(
         if (endState.date != endDate) endViewModel.setDate(endDate)
     }
 
-    LaunchedEffect(startState.date) {
-        if (startState.date != startDate) onStartDateChanged(startState.date)
-    }
-    LaunchedEffect(endState.date) {
-        if (endState.date != endDate) onEndDateChanged(endState.date)
+    LaunchedEffect(startState.date, endState.date) {
+        if (applyOnlyCompleteRange) {
+            val update =
+                resolveSearchDateRangeNavigation(
+                    appliedStart = startDate,
+                    appliedEnd = endDate,
+                    draftStart = startState.date,
+                    draftEnd = endState.date,
+                )
+            if (update != null) {
+                onDateRangeChanged(update.startDate, update.endDate)
+            }
+        } else {
+            if (startState.date != startDate || endState.date != endDate) {
+                onDateRangeChanged(startState.date, endState.date)
+            }
+        }
     }
 
     Row(

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarAvailabilityPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarAvailabilityPage.kt
@@ -78,8 +78,10 @@ fun CarAvailabilityPage() {
                             SearchDateRangeSelector(
                                 startDate = currentState.selectedStartDate,
                                 endDate = currentState.selectedEndDate,
-                                onStartDateChanged = viewModel::updateSelectedStartDate,
-                                onEndDateChanged = viewModel::updateSelectedEndDate,
+                                onDateRangeChanged = { start, end ->
+                                    viewModel.updateSelectedStartDate(start)
+                                    viewModel.updateSelectedEndDate(end)
+                                },
                                 disabledDates = currentState.disabledDates,
                                 endMinOffsetDaysFromStart = 0,
                                 clearRangeOnCancel = false,

--- a/SearchCore/src/commonTest/kotlin/my/drivebit/search/SearchViewModelTest.kt
+++ b/SearchCore/src/commonTest/kotlin/my/drivebit/search/SearchViewModelTest.kt
@@ -140,4 +140,37 @@ class SearchViewModelTest {
             assertEquals(2, results.filters.page)
             assertEquals("2", results.result.cars.first().id)
         }
+
+    @Test
+    fun `brand then body type load completes with both filters`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            var lastFilters: SearchFilterSet? = null
+            val vm =
+                SearchViewModel(
+                    repositoryFactory = { filters ->
+                        lastFilters = filters
+                        object : SearchCarRepository {
+                            override val results: Flow<SearchCarsResult> =
+                                flowOf(SearchCarsResult(totalCount = 0, totalPages = 0))
+                        }
+                    },
+                    brandResolver = { slug -> if (slug == "bmw") 10 to "BMW" else null },
+                    modelResolver = { _, _ -> null },
+                    coroutineScope = CoroutineScope(SupervisorJob() + dispatcher),
+                )
+
+            vm.load("/bmw")
+            advanceUntilIdle()
+            vm.load("/bmw?bodyType=SUV&bodyTypeLabel=%D0%92%D0%BD%D0%B5%D0%B4%D0%BE%D1%80%D0%BE%D0%B6%D0%BD%D0%B8%D0%BA")
+            advanceUntilIdle()
+
+            val results = assertIs<SearchUiState.Results>(vm.state.value)
+            assertEquals(10, results.filters.brandId)
+            assertEquals("BMW", results.filters.brandName)
+            assertEquals("SUV", results.filters.bodyType)
+            assertEquals("Внедорожник", results.filters.bodyTypeLabel)
+            assertEquals("SUV", lastFilters?.bodyType)
+            assertEquals(10, lastFilters?.brandId)
+        }
 }

--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/SearchDateRangeNavigation.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/SearchDateRangeNavigation.kt
@@ -1,0 +1,30 @@
+package my.drivebit.utils
+
+data class SearchDateRangeUpdate(
+    val startDate: String?,
+    val endDate: String?,
+)
+
+/**
+ * Search dates are applied only as a complete «с»+«по» pair (or cleared together).
+ * A partial draft (only start or only end) must not navigate / reload search.
+ */
+fun resolveSearchDateRangeNavigation(
+    appliedStart: String?,
+    appliedEnd: String?,
+    draftStart: String?,
+    draftEnd: String?,
+): SearchDateRangeUpdate? {
+    val draftComplete = draftStart != null && draftEnd != null
+    val draftCleared = draftStart == null && draftEnd == null
+    val appliedHasRange = appliedStart != null || appliedEnd != null
+
+    return when {
+        draftComplete -> {
+            val update = SearchDateRangeUpdate(startDate = draftStart, endDate = draftEnd)
+            if (update.startDate == appliedStart && update.endDate == appliedEnd) null else update
+        }
+        draftCleared && appliedHasRange -> SearchDateRangeUpdate(startDate = null, endDate = null)
+        else -> null
+    }
+}

--- a/Utils/src/commonTest/kotlin/my/drivebit/utils/SearchDateRangeNavigationTest.kt
+++ b/Utils/src/commonTest/kotlin/my/drivebit/utils/SearchDateRangeNavigationTest.kt
@@ -1,0 +1,106 @@
+package my.drivebit.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SearchDateRangeNavigationTest {
+    @Test
+    fun `partial start only does not navigate`() {
+        assertNull(
+            resolveSearchDateRangeNavigation(
+                appliedStart = null,
+                appliedEnd = null,
+                draftStart = "2026-07-20",
+                draftEnd = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `partial end only does not navigate`() {
+        assertNull(
+            resolveSearchDateRangeNavigation(
+                appliedStart = null,
+                appliedEnd = null,
+                draftStart = null,
+                draftEnd = "2026-07-25",
+            ),
+        )
+    }
+
+    @Test
+    fun `complete pair navigates with both dates`() {
+        assertEquals(
+            SearchDateRangeUpdate(startDate = "2026-07-20", endDate = "2026-07-25"),
+            resolveSearchDateRangeNavigation(
+                appliedStart = null,
+                appliedEnd = null,
+                draftStart = "2026-07-20",
+                draftEnd = "2026-07-25",
+            ),
+        )
+    }
+
+    @Test
+    fun `same complete pair as applied does not navigate again`() {
+        assertNull(
+            resolveSearchDateRangeNavigation(
+                appliedStart = "2026-07-20",
+                appliedEnd = "2026-07-25",
+                draftStart = "2026-07-20",
+                draftEnd = "2026-07-25",
+            ),
+        )
+    }
+
+    @Test
+    fun `clearing both dates navigates clear when previous range applied`() {
+        assertEquals(
+            SearchDateRangeUpdate(startDate = null, endDate = null),
+            resolveSearchDateRangeNavigation(
+                appliedStart = "2026-07-20",
+                appliedEnd = "2026-07-25",
+                draftStart = null,
+                draftEnd = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `already clear stays without navigation`() {
+        assertNull(
+            resolveSearchDateRangeNavigation(
+                appliedStart = null,
+                appliedEnd = null,
+                draftStart = null,
+                draftEnd = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `replacing complete pair navigates new range`() {
+        assertEquals(
+            SearchDateRangeUpdate(startDate = "2026-08-01", endDate = "2026-08-10"),
+            resolveSearchDateRangeNavigation(
+                appliedStart = "2026-07-20",
+                appliedEnd = "2026-07-25",
+                draftStart = "2026-08-01",
+                draftEnd = "2026-08-10",
+            ),
+        )
+    }
+
+    @Test
+    fun `restarting range after complete pair waits for new end`() {
+        assertNull(
+            resolveSearchDateRangeNavigation(
+                appliedStart = "2026-07-20",
+                appliedEnd = "2026-07-25",
+                draftStart = "2026-08-01",
+                draftEnd = null,
+            ),
+        )
+    }
+}

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -124,7 +124,24 @@ fun SearchApp() {
     val filtersForUi =
         when (val s = state) {
             is SearchUiState.Results -> s.filters
-            else -> lastFilters ?: filtersFromLocation(locationHref)
+            else -> {
+                val fromUrl = filtersFromLocation(locationHref)
+                val previous = lastFilters
+                if (previous != null &&
+                    previous.brandSlug == fromUrl.brandSlug &&
+                    previous.modelSlug == fromUrl.modelSlug &&
+                    previous.citySlug == fromUrl.citySlug
+                ) {
+                    fromUrl.copy(
+                        brandId = previous.brandId,
+                        brandName = previous.brandName,
+                        modelId = previous.modelId,
+                        modelName = previous.modelName,
+                    )
+                } else {
+                    fromUrl
+                }
+            }
         }
 
     val pathOnly = locationHref.substringBefore('?').substringBefore('#')
@@ -135,6 +152,9 @@ fun SearchApp() {
             cityName = searchCityName,
         )
 
+    val resultsState = state as? SearchUiState.Results
+    val errorMessage = (state as? SearchUiState.Error)?.message
+
     Div({
         style {
             width(100.percent)
@@ -144,30 +164,13 @@ fun SearchApp() {
             property("box-sizing", "border-box")
         }
     }) {
-        when (val currentState = state) {
-            is SearchUiState.Loading -> {
-                SearchResultsContent(
-                    filters = filtersForUi,
-                    result = null,
-                    pageHeadline = pageHeadline,
-                    onLocationChanged = { locationHref = currentLocationHref() },
-                )
-            }
-
-            is SearchUiState.Error -> {
-                SearchPageHeadline(pageHeadline)
-                TextError(currentState.message)
-            }
-
-            is SearchUiState.Results -> {
-                SearchResultsContent(
-                    filters = currentState.filters,
-                    result = currentState.result,
-                    pageHeadline = pageHeadline,
-                    onLocationChanged = { locationHref = currentLocationHref() },
-                )
-            }
-        }
+        SearchResultsContent(
+            filters = resultsState?.filters ?: filtersForUi,
+            result = resultsState?.result,
+            pageHeadline = pageHeadline,
+            errorMessage = errorMessage,
+            onLocationChanged = { locationHref = currentLocationHref() },
+        )
     }
 }
 
@@ -198,6 +201,7 @@ private fun SearchResultsContent(
     filters: SearchFilterSet,
     result: SearchCarsResult?,
     pageHeadline: String,
+    errorMessage: String? = null,
     onLocationChanged: () -> Unit,
 ) {
     var showPriceFilter by remember { mutableStateOf(false) }
@@ -289,17 +293,14 @@ private fun SearchResultsContent(
         SearchDateRangeSelector(
             startDate = filters.startDate,
             endDate = filters.endDate,
-            onStartDateChanged = { date ->
-                if (date != filters.startDate) {
-                    navigateFilter { it.copy(startDate = date) }
-                }
-            },
-            onEndDateChanged = { date ->
-                if (date != filters.endDate) {
-                    navigateFilter { it.copy(endDate = date) }
-                }
+            applyOnlyCompleteRange = true,
+            onDateRangeChanged = { start, end ->
+                navigateFilter { it.copy(startDate = start, endDate = end) }
             },
         )
+        if (errorMessage != null) {
+            TextError(errorMessage)
+        }
         FlowRow(gap = 8.px) {
             FilterChip(
                 name = "Марка",
@@ -495,6 +496,8 @@ private fun SearchResultsContent(
                 if (showBrandFilter) {
                     BoxOverlay {
                         BrandModelFilter(
+                            initialBrandId = filters.brandId,
+                            initialBrandName = filters.brandName,
                             onBrandSelected = { brandId, brandName ->
                                 navigateFilter {
                                     it.copy(


### PR DESCRIPTION
## Summary
- Keep search filter UI mounted across Loading/Results so brand→model selection and overlays are not wiped
- Apply rental dates only as a complete «с»+«по» pair (or clear both)
- Prefer URL filters while loading so brand+bodyType does not drop the brand mid-flight

## Test plan
- [ ] CI green on this PR
- [ ] Open Марка → pick brand → model list appears; pick model or Ок
- [ ] Calendar: pick start then end; URL/search updates only after both
- [ ] Brand then Кузов completes search (not stuck on shimmer)


Made with [Cursor](https://cursor.com)