### PR TITLE
test(smoke): Callibri gate on search and brand pages

### DIFF
--- a/.cursor/skills/drivebit-ship-release/SKILL.md
+++ b/.cursor/skills/drivebit-ship-release/SKILL.md
@@ -131,23 +131,25 @@ Default base URL: `https://drivebit.ru`. Exit code **0** required.
 
 | Check | Gate |
 |-------|------|
-| HTTP 200 | `/moskva`, `/search`, `/login`, `/contacts`, `/list-your-car.html` |
-| Compose mount | `#root` has content on `/moskva` and `/search` |
+| HTTP 200 | `/moskva`, `/moskva/search`, `/bmw`, `/bmw/x5`, `/login`, `/contacts`, `/list-your-car.html` |
+| Compose mount | `#root` has content on city, search, brand, brand-model pages |
 | Third-party loader | `drivebit-third-party-deferred.js` in HTML on all key pages |
-| Navigation | Hero button «Найти автомобиль» opens `/search` |
-| Vendor assets | `/vendor/drivebit-third-party-deferred.js` served (classic `defer`, not `type=module`) |
-| JS errors | No `pageerror` on any checked page |
+| **Callibri** | `cdn.callibri.ru/callibri.js` script tag present on city, **search**, **brand** (`/bmw`), **brand-model** (`/bmw/x5`), contacts, login — same as other screens |
+| Navigation | Hero button «Найти автомобиль» opens `/{city}/search` |
+| Vendor assets | `/vendor/drivebit-third-party-deferred.js` and scheduler `.mjs` served |
+| JS errors | No `pageerror` on any checked page (benign Callibri headless noise ignored) |
 
-**Analytics note:** Metrika/Callibri may not load in headless Playwright (ad-block / external scripts). The smoke script reports `analytics` info but does not fail on it. For analytics-only releases, additionally spot-check in a real browser: Network tab → `metrika/tag.js` before `callibri.js`.
+**Callibri gate (required every ship):** smoke must fail if Callibri is missing on search or brand folders. Do not announce prod OK when `hasCallibriScript` is false for those paths. Network load of Callibri may still be blocked in headless; the hard gate is the HTML script tag. Optional real-browser spot-check: console → `callibriInit()` → `undefined`.
 
 **Optional manual spot-check** (browser or `cursor-ide-browser`):
 
 1. https://drivebit.ru/moskva — hero, filters, car grid render
-2. Click «Найти автомобиль» → `/search` with results UI
-3. Header links: «Контакты», «Сдать авто»
-4. https://drivebit.ru/login — auth shell loads (may redirect if already logged in)
+2. Click «Найти автомобиль» → `/moskva/search` with results UI + Callibri in page source
+3. https://drivebit.ru/bmw and https://drivebit.ru/bmw/x5 — search shell + Callibri script tag
+4. Header links: «Контакты», «Сдать авто»
+5. https://drivebit.ru/login — auth shell loads (may redirect if already logged in)
 
-Report in final message: release URL + deploy run URL + smoke test output summary.
+Report in final message: release URL + deploy run URL + smoke test output summary (include Callibri pass/fail for search + brand).
 
 ## Quick Reference
 
@@ -170,6 +172,7 @@ Report in final message: release URL + deploy run URL + smoke test output summar
 | Merge before CI green | Wait for `gh pr checks --watch` |
 | Skip deploy watch | Release ≠ deployed until `deploy.yml` succeeds |
 | Skip prod smoke | Deploy success ≠ site works; run `npm run verify:prod-smoke` |
+| Skip Callibri on search/brand | Smoke must assert `callibri.js` on `/moskva/search`, `/bmw`, `/bmw/x5` |
 | Wrong version | Always read `gh release list --limit 1` first |
 | Broad local `./gradlew check` for CI debug | Run only the failing module/task from the log |
 
@@ -177,6 +180,7 @@ Report in final message: release URL + deploy run URL + smoke test output summar
 
 - Announcing «готово» / «на проде» without deploy run exit code 0
 - Announcing «на проде» without `npm run verify:prod-smoke` exit code 0
+- Announcing prod OK when Callibri is missing on search or brand pages
 - Pushing to `trunk` directly (except emergency hotfix per `.cursorrules`)
 - Creating release before merge to `trunk`
 - Leaving unrelated files in the commit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,48 +132,65 @@ jobs:
         fi
         test -f "$DIST/profile/index.html"
         test -f "$DIST/profile.js"
+        # Short brand landings must stay at dist root (SEO + Callibri)
+        for brand in bmw audi; do
+          if [ ! -f "$DIST/$brand/index.html" ] && [ -f "composeApp/src/jsMain/resources/$brand/index.html" ]; then
+            mkdir -p "$DIST/$brand"
+            cp "composeApp/src/jsMain/resources/$brand/index.html" "$DIST/$brand/index.html"
+          fi
+        done
+        if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
+          cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
+        fi
         echo "split bundles merged OK"
 
     - name: Verify Moscow SEO pages in dist
       run: |
-        set -e
+        set -euo pipefail
         DIST="composeApp/build/dist/js/productionExecutable"
-        test -f "$DIST/moskva/poblizosti/index.html"
-        grep -q 'drivebit-cars-grid-static' "$DIST/moskva/poblizosti/index.html"
-        grep -q 'src="/composeApp.js' "$DIST/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html"
+        fail() { echo "SEO verify failed: $*" >&2; exit 1; }
+        test -f "$DIST/moskva/poblizosti/index.html" || fail "missing moskva/poblizosti"
+        grep -q 'drivebit-cars-grid-static' "$DIST/moskva/poblizosti/index.html" || fail "poblizosti grid"
+        grep -q 'src="/composeApp.js' "$DIST/moskva/arenda-avto-ekonom-klassa-bez-voditelya/index.html" || fail "ekonom composeApp.js"
         for slug in "" arenda-avto-v-krym arenda-avto-v-belarus arenda-avto-v-abkhaziyu arenda-avto-ekonom-klassa-bez-voditelya arenda-avto-komfort-klassa-bez-voditelya arenda-avto-biznes-klassa-bez-voditelya arenda-avto-premium-klassa-bez-voditelya arenda-minivena-bez-voditelya arenda-vnedorozhnika-bez-voditelya poblizosti; do
           if [ -z "$slug" ]; then
             page="$DIST/moskva/index.html"
           else
             page="$DIST/moskva/$slug/index.html"
           fi
-          test -f "$page"
+          test -f "$page" || fail "missing $page"
         done
         echo "Moscow SEO landing pages OK"
-        test -f "$DIST/bmw/index.html"
-        grep -q 'drivebit-seo-text' "$DIST/bmw/index.html"
-        grep -q 'drivebit-page-headline' "$DIST/bmw/index.html"
-        grep -q '<h1' "$DIST/bmw/index.html"
-        grep -q 'Аренда BMW без водителя в Москве' "$DIST/bmw/index.html"
-        test -f "$DIST/audi/index.html"
-        grep -q 'Аренда Audi без водителя в Москве' "$DIST/audi/index.html"
-        test -f "$DIST/search/bmw/index.html"
-        grep -q 'canonical' "$DIST/search/bmw/index.html"
-        test -f "$DIST/moskva/search/index.html"
-        grep -q 'drivebit-page-headline' "$DIST/moskva/search/index.html"
-        grep -q 'Поиск автомобилей для аренды в Москве' "$DIST/moskva/search/index.html"
-        test -f "$DIST/kaliningrad/search/index.html"
-        test -f "$DIST/krasnogorsk/search/index.html"
-        test -f "$DIST/lyubertsy/search/index.html"
-        test -f "$DIST/zelenograd/search/index.html"
-        test -f "$DIST/rostov-na-donu/index.html"
-        test -f "$DIST/rostov-na-donu/search/index.html"
-        grep -q 'Поиск автомобилей для аренды в Ростове-на-Дону' "$DIST/rostov-na-donu/search/index.html"
-        test -f "$DIST/search/index.html"
-        grep -q 'moskva/search' "$DIST/search/index.html"
+        test -f "$DIST/bmw/index.html" || fail "missing bmw/index.html (ls=$(ls -la "$DIST" | head))"
+        grep -q 'drivebit-seo-text' "$DIST/bmw/index.html" || fail "bmw seo-text"
+        grep -q 'drivebit-page-headline' "$DIST/bmw/index.html" || fail "bmw headline"
+        grep -q '<h1' "$DIST/bmw/index.html" || fail "bmw h1"
+        grep -q 'Аренда BMW без водителя в Москве' "$DIST/bmw/index.html" || fail "bmw h1 text"
+        grep -q 'callibri.js' "$DIST/bmw/index.html" || fail "bmw Callibri"
+        grep -q 'drivebit-third-party-deferred' "$DIST/bmw/index.html" || fail "bmw third-party loader"
+        test -f "$DIST/audi/index.html" || fail "missing audi/index.html"
+        grep -q 'Аренда Audi без водителя в Москве' "$DIST/audi/index.html" || fail "audi h1 text"
+        grep -q 'callibri.js' "$DIST/audi/index.html" || fail "audi Callibri"
+        test -f "$DIST/search/bmw/index.html" || fail "missing search/bmw"
+        grep -q 'canonical' "$DIST/search/bmw/index.html" || fail "search/bmw canonical"
+        test -f "$DIST/moskva/search/index.html" || fail "missing moskva/search"
+        grep -q 'drivebit-page-headline' "$DIST/moskva/search/index.html" || fail "moskva/search headline"
+        grep -q 'Поиск автомобилей для аренды в Москве' "$DIST/moskva/search/index.html" || fail "moskva/search h1 text"
+        grep -q 'callibri.js' "$DIST/moskva/search/index.html" || fail "moskva/search Callibri"
+        grep -q 'drivebit-third-party-deferred' "$DIST/moskva/search/index.html" || fail "moskva/search third-party"
+        test -f "$DIST/kaliningrad/search/index.html" || fail "kaliningrad/search"
+        test -f "$DIST/krasnogorsk/search/index.html" || fail "krasnogorsk/search"
+        test -f "$DIST/lyubertsy/search/index.html" || fail "lyubertsy/search"
+        test -f "$DIST/zelenograd/search/index.html" || fail "zelenograd/search"
+        test -f "$DIST/rostov-na-donu/index.html" || fail "rostov index"
+        test -f "$DIST/rostov-na-donu/search/index.html" || fail "rostov/search"
+        grep -q 'Поиск автомобилей для аренды в Ростове-на-Дону' "$DIST/rostov-na-donu/search/index.html" || fail "rostov/search h1"
+        test -f "$DIST/search/index.html" || fail "search/index"
+        grep -q 'moskva/search' "$DIST/search/index.html" || fail "search redirect"
         echo "Search brand SEO pages OK"
-        test -f "$DIST/contacts/index.html"
-        grep -q 'drivebit-contacts-page' "$DIST/contacts/index.html"
+        test -f "$DIST/contacts/index.html" || fail "contacts"
+        grep -q 'drivebit-contacts-page' "$DIST/contacts/index.html" || fail "contacts marker"
+        grep -q 'callibri.js' "$DIST/contacts/index.html" || fail "contacts Callibri"
         echo "Contacts static page OK"
 
     - name: Show built index.html title

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -79,6 +79,15 @@ jobs:
         cp -r "$PROFILE/profile" "$DIST/"
         test -f "$DIST/profile/index.html"
         test -f "$DIST/profile.js"
+        for brand in bmw audi; do
+          if [ ! -f "$DIST/$brand/index.html" ] && [ -f "composeApp/src/jsMain/resources/$brand/index.html" ]; then
+            mkdir -p "$DIST/$brand"
+            cp "composeApp/src/jsMain/resources/$brand/index.html" "$DIST/$brand/index.html"
+          fi
+        done
+        if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
+          cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
+        fi
         echo "split bundles merged OK"
 
     - name: Prepare dist directory

--- a/scripts/verify-prod-smoke.mjs
+++ b/scripts/verify-prod-smoke.mjs
@@ -10,10 +10,22 @@ const base = (process.argv[2] || "https://drivebit.ru").replace(/\/$/, "");
 const PAGES = [
   { path: "/moskva", name: "city landing" },
   { path: "/moskva/search", name: "search" },
+  { path: "/bmw", name: "brand search" },
+  { path: "/bmw/x5", name: "brand model search" },
   { path: "/login", name: "login shell" },
   { path: "/contacts", name: "contacts" },
   { path: "/list-your-car.html", name: "list your car" },
 ];
+
+/** Pages that must embed Callibri the same way as city landing. */
+const CALLIBRI_REQUIRED = new Set([
+  "city landing",
+  "search",
+  "brand search",
+  "brand model search",
+  "contacts",
+  "login shell",
+]);
 
 const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
@@ -27,13 +39,23 @@ for (const { path, name } of PAGES) {
   const response = await page.goto(url, { waitUntil: "load", timeout: 60000 });
   await page.waitForTimeout(path === "/moskva" ? 8000 : 4000);
 
-  const report = await page.evaluate(() => ({
-    hasComposeApp: !!document.querySelector('script[src*="composeApp.js"]'),
-    hasThirdPartyLoader: !!document.querySelector('script[src*="drivebit-third-party-deferred"]'),
-    hasRoot: !!document.getElementById("root"),
-    rootLen: document.getElementById("root")?.innerHTML?.length ?? 0,
-    title: document.title,
-  }));
+  const report = await page.evaluate(() => {
+    const scripts = Array.from(document.scripts);
+    const hasComposeBundle = scripts.some(
+      (s) =>
+        /composeApp\.js/.test(s.src) ||
+        /appCompose\.js/.test(s.src) ||
+        /searchApp\.js/.test(s.src),
+    );
+    return {
+      hasComposeApp: hasComposeBundle,
+      hasThirdPartyLoader: scripts.some((s) => /drivebit-third-party-deferred/.test(s.src)),
+      hasCallibriScript: scripts.some((s) => /callibri\.js/.test(s.src)),
+      hasRoot: !!document.getElementById("root"),
+      rootLen: document.getElementById("root")?.innerHTML?.length ?? 0,
+      title: document.title,
+    };
+  });
 
   results.push({
     name,
@@ -79,26 +101,40 @@ const failures = [];
 for (const item of results) {
   if (item.status !== 200) failures.push(`${item.name}: HTTP ${item.status}`);
   if (!item.hasThirdPartyLoader) failures.push(`${item.name}: missing third-party loader`);
-  if (item.path !== "/list-your-car.html" && !item.hasComposeApp && item.name !== "list your car") {
-    if (!item.hasComposeApp) failures.push(`${item.name}: missing composeApp.js`);
+  if (CALLIBRI_REQUIRED.has(item.name) && !item.hasCallibriScript) {
+    failures.push(`${item.name}: missing Callibri script (cdn.callibri.ru/callibri.js)`);
   }
-  if (item.name === "city landing" || item.name === "search") {
+  if (item.path !== "/list-your-car.html") {
+    if (!item.hasComposeApp) failures.push(`${item.name}: missing compose/search app bundle`);
+  }
+  if (
+    item.name === "city landing" ||
+    item.name === "search" ||
+    item.name === "brand search" ||
+    item.name === "brand model search"
+  ) {
     if (!item.hasRoot || item.rootLen <= 0) failures.push(`${item.name}: compose root empty`);
   }
 }
 
 if (!navigationOk) failures.push("navigation: hero search button did not open /{city}/search");
 
-const vendorScheduler = await fetch(`${base}/vendor/drivebit-third-party-scheduler.mjs`).then(
-  (r) => r.ok,
-).catch(() => false);
+const vendorDeferred = await fetch(`${base}/vendor/drivebit-third-party-deferred.js`)
+  .then((r) => r.ok)
+  .catch(() => false);
+if (!vendorDeferred) failures.push("vendor: drivebit-third-party-deferred.js not served");
+
+const vendorScheduler = await fetch(`${base}/vendor/drivebit-third-party-scheduler.mjs`)
+  .then((r) => r.ok)
+  .catch(() => false);
 if (!vendorScheduler) failures.push("vendor: drivebit-third-party-scheduler.mjs not served");
 
 const analytics = {
   ...thirdParty,
+  vendorDeferred,
   vendorScheduler,
   note:
-    "Metrika/Callibri may be blocked in headless; verify order manually in browser DevTools if needed.",
+    "Callibri script tag in HTML is a hard gate. Metrika/Callibri network load may be blocked in headless; verify callibriInit() in a real browser if needed.",
 };
 
 for (const err of pageErrors) {


### PR DESCRIPTION
## Summary
- Prod smoke now hard-fails if Callibri script tag is missing on `/moskva/search`, `/bmw`, `/bmw/x5` (same as other screens)
- `drivebit-ship-release` skill documents Callibri as a required every-ship gate

## Test plan
- [ ] CI green
- [ ] `npm run verify:prod-smoke` after merge/deploy shows `hasCallibriScript: true` for search + brand


Made with [Cursor](https://cursor.com)