### PR TITLE
fix(web): keep /search redirect stub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,9 @@ jobs:
         if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
           cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
         fi
+        # /search must remain the redirect stub to /moskva/search (never a bare SPA shell)
+        mkdir -p "$DIST/search"
+        cp "composeApp/src/jsMain/resources/search/index.html" "$DIST/search/index.html"
         echo "split bundles merged OK"
 
     - name: Verify Moscow SEO pages in dist

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -88,6 +88,8 @@ jobs:
         if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
           cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
         fi
+        mkdir -p "$DIST/search"
+        cp "composeApp/src/jsMain/resources/search/index.html" "$DIST/search/index.html"
         echo "split bundles merged OK"
 
     - name: Prepare dist directory

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -408,9 +408,9 @@ tasks.named<org.gradle.api.tasks.Copy>("jsProcessResources").configure {
     from(accountWebpackDir) {
         include("account.js", "account.js.map")
     }
-    from(project(":searchApp").layout.buildDirectory.dir("processedResources/js/main/search-shell")) {
-        into("search")
-    }
+    // Do not copy search-shell into search/ — that overwrites the SEO redirect at /search
+    // (composeApp/src/jsMain/resources/search/index.html → /moskva/search). City search
+    // pages load /appCompose.js directly; the bare shell is only for searchApp standalone.
     val searchWebpackDir =
         if (needsSplitBundleDevWebpack) {
             project(":searchApp").layout.buildDirectory.dir("kotlin-webpack/js/developmentExecutable")

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:third-party": "node --test scripts/drivebit-third-party-scheduler.test.mjs",
+    "test:search-redirect": "node --test scripts/search-index-redirect.test.mjs",
     "verify:third-party-loader": "node scripts/verify-third-party-loader.mjs",
     "verify:prod-smoke": "node scripts/verify-prod-smoke.mjs"
   },

--- a/scripts/search-index-redirect.test.mjs
+++ b/scripts/search-index-redirect.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const searchIndex = path.join(root, "composeApp/src/jsMain/resources/search/index.html");
+
+describe("search/index.html redirect stub", () => {
+  it("points bare /search to /moskva/search (not a SPA shell)", () => {
+    const html = fs.readFileSync(searchIndex, "utf8");
+    assert.match(html, /moskva\/search/);
+    assert.match(html, /location\.replace\('\/moskva\/search'/);
+    assert.doesNotMatch(html, /appCompose\.js/);
+    assert.doesNotMatch(html, /id="root"/);
+  });
+});


### PR DESCRIPTION
## Summary
- `jsProcessResources` no longer copies searchApp `search-shell` into `search/`, which overwrote the `/search` → `/moskva/search` redirect with a bare SPA shell (broke deploy SEO verify).
- Deploy and GitHub Pages always restore `search/index.html` from resources.
- Adds a node contract test for the redirect stub.

## Test plan
- [x] `npm run test:search-redirect`
- [ ] CI green
- [ ] Deploy SEO verify passes (`search redirect`)
- [ ] Prod smoke includes Callibri on `/moskva/search`, `/bmw`, `/bmw/x5`


Made with [Cursor](https://cursor.com)