### PR TITLE
fix(web): /search → selected city search

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,9 @@ jobs:
         if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
           cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
         fi
+        # /search must remain the redirect stub (city from my_city_slug, fallback moskva)
+        mkdir -p "$DIST/search"
+        cp "composeApp/src/jsMain/resources/search/index.html" "$DIST/search/index.html"
         echo "split bundles merged OK"
 
     - name: Verify Moscow SEO pages in dist

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -88,6 +88,8 @@ jobs:
         if [ ! -f "$DIST/rostov-na-donu/index.html" ] && [ -d "composeApp/src/jsMain/resources/rostov-na-donu" ]; then
           cp -R "composeApp/src/jsMain/resources/rostov-na-donu" "$DIST/"
         fi
+        mkdir -p "$DIST/search"
+        cp "composeApp/src/jsMain/resources/search/index.html" "$DIST/search/index.html"
         echo "split bundles merged OK"
 
     - name: Prepare dist directory

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/MyCityRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/MyCityRepository.kt
@@ -8,10 +8,12 @@ import kotlinx.coroutines.flow.flow
 import my.drivebit.network.services.City
 import my.drivebit.network.services.Dictionary
 import my.drivebit.shared.storage.Storage
+import my.drivebit.utils.cityNameToSlug
 
 object MyCityStorageKeys {
     const val ID_KEY = "my_city_id"
     const val NAME_KEY = "my_city_name"
+    const val SLUG_KEY = "my_city_slug"
 }
 
 interface MyCityRepository {
@@ -97,8 +99,10 @@ internal class MyCityRepositoryImpl(
         cityId: Int,
         cityName: String,
     ) {
+        val slug = cityNameToSlug(cityName).takeIf { it.isNotEmpty() && it != "city" } ?: "moskva"
         storage.putString(MyCityStorageKeys.ID_KEY, cityId.toString())
         storage.putString(MyCityStorageKeys.NAME_KEY, cityName)
+        storage.putString(MyCityStorageKeys.SLUG_KEY, slug)
         selectedCityFlow.value = City(id = cityId, name = cityName)
     }
 }

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/MyCityRepositoryTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/MyCityRepositoryTest.kt
@@ -231,6 +231,7 @@ class MyCityRepositoryTest {
             val cityNameInStorage = storage.getString(MyCityStorageKeys.NAME_KEY)
             assertEquals("158831", cityIdInStorage)
             assertEquals("Санкт-Петербург", cityNameInStorage)
+            assertEquals("sankt-peterburg", storage.getString(MyCityStorageKeys.SLUG_KEY))
         }
 
     @Test

--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/CitySearchPathUtils.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/CitySearchPathUtils.kt
@@ -21,3 +21,21 @@ fun buildCitySearchPath(
 }
 
 fun isCitySearchPath(pathname: String): Boolean = parseCitySlugFromSearchPath(pathname) != null
+
+/**
+ * Bare `/search` → `/{city}/search` from MyCityRepository city name.
+ * Missing/invalid city falls back to Moscow (`moskva`).
+ */
+fun resolveBareSearchRedirectPath(
+    selectedCityName: String?,
+    queryWithoutQuestionMark: String? = null,
+): String {
+    val slug =
+        selectedCityName
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let(::cityNameToSlug)
+            ?.takeIf { it.isNotEmpty() && it != "city" }
+            ?: "moskva"
+    return buildCitySearchPath(slug, queryWithoutQuestionMark)
+}

--- a/Utils/src/commonTest/kotlin/my/drivebit/utils/CitySearchPathUtilsTest.kt
+++ b/Utils/src/commonTest/kotlin/my/drivebit/utils/CitySearchPathUtilsTest.kt
@@ -39,4 +39,34 @@ class CitySearchPathUtilsTest {
         assertFalse(isCitySearchPath("/moskva"))
         assertFalse(isCitySearchPath("/moskva/poblizosti"))
     }
+
+    @Test
+    fun resolveBareSearchRedirectPath_usesSelectedCityFromRepository() {
+        assertEquals("/kaliningrad/search", resolveBareSearchRedirectPath("Калининград"))
+        assertEquals("/rostov-na-donu/search", resolveBareSearchRedirectPath("Ростов-на-Дону"))
+        assertEquals("/moskva/search", resolveBareSearchRedirectPath("Москва"))
+    }
+
+    @Test
+    fun resolveBareSearchRedirectPath_fallsBackToMoskvaWhenCityMissing() {
+        assertEquals("/moskva/search", resolveBareSearchRedirectPath(null))
+        assertEquals("/moskva/search", resolveBareSearchRedirectPath(""))
+        assertEquals("/moskva/search", resolveBareSearchRedirectPath("   "))
+        assertEquals("/moskva/search", resolveBareSearchRedirectPath("@@@"))
+    }
+
+    @Test
+    fun resolveBareSearchRedirectPath_preservesQuery() {
+        assertEquals(
+            "/kaliningrad/search?startDate=2026-04-25&endDate=2026-04-30",
+            resolveBareSearchRedirectPath(
+                "Калининград",
+                "startDate=2026-04-25&endDate=2026-04-30",
+            ),
+        )
+        assertEquals(
+            "/moskva/search?page=2",
+            resolveBareSearchRedirectPath(null, "page=2"),
+        )
+    }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -408,9 +408,9 @@ tasks.named<org.gradle.api.tasks.Copy>("jsProcessResources").configure {
     from(accountWebpackDir) {
         include("account.js", "account.js.map")
     }
-    from(project(":searchApp").layout.buildDirectory.dir("processedResources/js/main/search-shell")) {
-        into("search")
-    }
+    // Do not copy search-shell into search/ — that overwrites the SEO redirect at /search
+    // (composeApp/src/jsMain/resources/search/index.html → /{city}/search from MyCity).
+    // City search pages load /appCompose.js directly; the bare shell is only for searchApp standalone.
     val searchWebpackDir =
         if (needsSplitBundleDevWebpack) {
             project(":searchApp").layout.buildDirectory.dir("kotlin-webpack/js/developmentExecutable")

--- a/composeApp/src/jsMain/resources/search/index.html
+++ b/composeApp/src/jsMain/resources/search/index.html
@@ -7,7 +7,19 @@
     <meta name="robots" content="noindex, follow">
     <link rel="canonical" href="https://drivebit.ru/moskva/search">
     <meta http-equiv="refresh" content="0; url=/moskva/search">
-    <script>location.replace('/moskva/search' + location.search + location.hash);</script>
+    <script>
+        (function () {
+            var FALLBACK = "moskva";
+            var slug = "";
+            try {
+                slug = localStorage.getItem("my_city_slug") || "";
+            } catch (e) {}
+            if (!/^[a-z0-9-]+$/.test(slug)) {
+                slug = FALLBACK;
+            }
+            location.replace("/" + slug + "/search" + location.search + location.hash);
+        })();
+    </script>
 </head>
 <body>
     <p>Страница переехала: <a href="/moskva/search">drivebit.ru/moskva/search</a></p>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:third-party": "node --test scripts/drivebit-third-party-scheduler.test.mjs",
+    "test:search-redirect": "node --test scripts/search-index-redirect.test.mjs",
     "verify:third-party-loader": "node scripts/verify-third-party-loader.mjs",
     "verify:prod-smoke": "node scripts/verify-prod-smoke.mjs"
   },

--- a/scripts/search-index-redirect.test.mjs
+++ b/scripts/search-index-redirect.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const searchIndex = path.join(root, "composeApp/src/jsMain/resources/search/index.html");
+
+describe("search/index.html redirect stub", () => {
+  it("redirects bare /search via MyCity slug with moskva fallback (not a SPA shell)", () => {
+    const html = fs.readFileSync(searchIndex, "utf8");
+    assert.match(html, /my_city_slug/);
+    assert.match(html, /moskva\/search/);
+    assert.match(html, /location\.replace\("\/" \+ slug \+ "\/search"/);
+    assert.doesNotMatch(html, /appCompose\.js/);
+    assert.doesNotMatch(html, /id="root"/);
+  });
+});

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -33,10 +33,10 @@ import my.drivebit.components.mileageFilterLabelForMin
 import my.drivebit.design.CSSColors
 import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
-import my.drivebit.utils.buildCitySearchPath
 import my.drivebit.utils.cityNameToSlug
 import my.drivebit.utils.isShortBrandSearchPath
 import my.drivebit.utils.parseSearchUrl
+import my.drivebit.utils.resolveBareSearchRedirectPath
 import my.drivebit.utils.uiIndexToUrlPage
 import my.drivebit.utils.urlPageToUiIndex
 import my.drivebit.repositories.MyCityRepository
@@ -83,7 +83,9 @@ fun SearchApp() {
                 .removeSuffix("/")
                 .ifEmpty { "/" }
         if (path == "/search") {
-            val target = buildCitySearchPath("moskva") + window.location.search
+            val cityName = runCatching { myCityRepository.getSelectedCity.first().name }.getOrNull()
+            val query = window.location.search.removePrefix("?").takeIf { it.isNotEmpty() }
+            val target = resolveBareSearchRedirectPath(cityName, query)
             window.history.replaceState(null, "", target)
             locationHref = currentLocationHref()
             return@LaunchedEffect


### PR DESCRIPTION
## Summary
- Bare `/search` redirects to `/{city}/search` from MyCity (slug in localStorage), fallback `moskva`
- Unit tests for `resolveBareSearchRedirectPath`
- Keep SEO redirect stub (do not overwrite with searchApp shell)
- Deploy/Pages restore `search/index.html`

## Test plan
- [x] `:Utils:jsTest` + `npm run test:search-redirect`
- [ ] CI green
- [ ] pages-dev: `/search` with city selected → city search; without → `/moskva/search`
- [ ] `/moskva`, `/moskva/search`, `/bmw`, login, contacts

Supersedes #291 (includes shell-overwrite fix).


Made with [Cursor](https://cursor.com)