### PR TITLE
fix(search): photos + empty-results skeleton

### DIFF
--- a/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
+++ b/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
@@ -51,7 +51,7 @@ class HttpSearchCarsApi(
                     driveTypes?.forEach { parameter("DriveType", it) }
                 }.body()
         return SearchCarsResult(
-            cars = paged.items,
+            cars = sanitizeSearchCarPhotoUrls(paged.items),
             totalCount = paged.totalCount,
             totalPages = paged.totalPages,
         )

--- a/SearchCore/src/commonMain/kotlin/my/drivebit/search/SanitizeSearchCarPhotoUrls.kt
+++ b/SearchCore/src/commonMain/kotlin/my/drivebit/search/SanitizeSearchCarPhotoUrls.kt
@@ -1,0 +1,26 @@
+package my.drivebit.search
+
+import my.drivebit.network.services.CarItem
+import my.drivebit.utils.extractPathFromApiUrl
+
+/** Rewrite direct MinIO host:9000 URLs to same-origin `/publicbct/...` paths for HTTPS pages. */
+fun sanitizeSearchCarPhotoUrls(items: List<CarItem>): List<CarItem> =
+    items.map { car ->
+        val photosFromGeneral = car.general.photos
+        val photosFromTopLevel = car.photos
+        val allPhotos = (photosFromGeneral + photosFromTopLevel).distinctBy { it.id }
+
+        car.copy(
+            photos =
+                allPhotos.map { photo ->
+                    photo.copy(url = extractPathFromApiUrl(photo.url))
+                },
+            general =
+                car.general.copy(
+                    photos =
+                        photosFromGeneral.map { photo ->
+                            photo.copy(url = extractPathFromApiUrl(photo.url))
+                        },
+                ),
+        )
+    }

--- a/SearchCore/src/commonTest/kotlin/my/drivebit/search/SanitizeSearchCarPhotoUrlsTest.kt
+++ b/SearchCore/src/commonTest/kotlin/my/drivebit/search/SanitizeSearchCarPhotoUrlsTest.kt
@@ -1,0 +1,51 @@
+package my.drivebit.search
+
+import my.drivebit.network.services.CarAddress
+import my.drivebit.network.services.CarGeneral
+import my.drivebit.network.services.CarItem
+import my.drivebit.network.services.CarPhotoItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class SanitizeSearchCarPhotoUrlsTest {
+    @Test
+    fun sanitizeSearchCarPhotoUrls_rewritesDirectMinioHttpToPublicPath() {
+        val raw =
+            "http://157.22.252.70:9000/publicbct/cars/" +
+                "bc71c63f-d244-4971-b194-9f4475b04c64/" +
+                "e7c4e756-f699-47b4-8f2e-909b80831334_compressed.jpg"
+        val car =
+            CarItem(
+                id = "1",
+                year = 2020,
+                price = 5000.0,
+                photos =
+                    listOf(
+                        CarPhotoItem(id = 1, url = raw, uploadDate = "2026-01-01"),
+                    ),
+                general =
+                    CarGeneral(
+                        brandName = "BMW",
+                        modelName = "X5",
+                        seats = 5,
+                        address = CarAddress(),
+                        photos =
+                            listOf(
+                                CarPhotoItem(id = 1, url = raw, uploadDate = "2026-01-01"),
+                            ),
+                    ),
+            )
+
+        val sanitized = sanitizeSearchCarPhotoUrls(listOf(car)).single()
+
+        assertEquals(
+            "/publicbct/cars/bc71c63f-d244-4971-b194-9f4475b04c64/" +
+                "e7c4e756-f699-47b4-8f2e-909b80831334_compressed.jpg",
+            sanitized.photos.single().url,
+        )
+        assertEquals(sanitized.photos.single().url, sanitized.general.photos.single().url)
+        assertFalse(sanitized.photos.single().url.contains("157.22.252.70"))
+        assertFalse(sanitized.photos.single().url.startsWith("http"))
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:third-party": "node --test scripts/drivebit-third-party-scheduler.test.mjs",
     "test:search-redirect": "node --test scripts/search-index-redirect.test.mjs",
+    "test:cars-grid-static": "node --test scripts/cars-grid-static-hide.test.mjs",
     "verify:third-party-loader": "node scripts/verify-third-party-loader.mjs",
     "verify:prod-smoke": "node scripts/verify-prod-smoke.mjs"
   },

--- a/scripts/cars-grid-static-hide.test.mjs
+++ b/scripts/cars-grid-static-hide.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cssPath = path.join(root, "vendor/drivebit-cars-grid-skeleton.css");
+
+describe("cars grid static shell hide rules", () => {
+  it("hides static skeleton when Compose shows empty search results", () => {
+    const css = fs.readFileSync(cssPath, "utf8");
+    assert.match(
+      css,
+      /body:has\(#root \.drivebit-search-results-empty\) #drivebit-cars-grid-static/,
+    );
+  });
+});

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -450,6 +450,7 @@ private fun SearchResultsContent(
                     }
                     else -> {
                         Div({
+                            classes("drivebit-search-results-empty")
                             style {
                                 padding(40.px)
                                 textAlign("center")

--- a/vendor/drivebit-cars-grid-skeleton.css
+++ b/vendor/drivebit-cars-grid-skeleton.css
@@ -47,6 +47,7 @@
 
 body:has(#root .drivebit-cars-grid-compose) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose),
 body:has(#root .drivebit-cars-grid-mounted) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose),
+body:has(#root .drivebit-search-results-empty) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose),
 body:has(#root .drivebit-pagination-bar) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose),
 body:has(#root .leaflet-container) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose),
 body:has(#root .drivebit-main-content-error) #drivebit-cars-grid-static:not(.drivebit-cars-grid-compose) {


### PR DESCRIPTION
## Summary
- Sanitize MinIO photo URLs in `HttpSearchCarsApi` (`/publicbct/...`) so HTTPS search shows car images
- Hide SEO static cars-grid skeleton when Compose shows empty results (`drivebit-search-results-empty`) — fixes «вечная загрузка» on empty filters e.g. `/search/abarth?bodyType=Wagon`

## Test plan
- [x] `:SearchCore:jsTest` + `npm run test:cars-grid-static`
- [ ] CI green
- [ ] pages-dev: empty filter shows «Автомобили не найдены» without skeleton above
- [ ] pages-dev/prod: `/moskva/search` car photos load via `/publicbct`