### PR TITLE
fix(search): friendly message on API 503 instead of Ktor dump

### DIFF
--- a/SearchCore/build.gradle.kts
+++ b/SearchCore/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.core)
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+            implementation("io.ktor:ktor-client-mock:${libs.versions.ktor.get()}")
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.android)

--- a/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
+++ b/SearchCore/src/commonMain/kotlin/my/drivebit/search/HttpSearchCarsApi.kt
@@ -1,9 +1,9 @@
 package my.drivebit.search
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import my.drivebit.network.parseResponse
 import my.drivebit.network.services.CarDTOPagedResult
 
 private const val BASE_URL = "https://drivebit.ru/api/"
@@ -49,7 +49,7 @@ class HttpSearchCarsApi(
                     brandId?.let { parameter("BrandId", it) }
                     modelId?.let { parameter("ModelId", it) }
                     driveTypes?.forEach { parameter("DriveType", it) }
-                }.body()
+                }.parseResponse()
         return SearchCarsResult(
             cars = sanitizeSearchCarPhotoUrls(paged.items),
             totalCount = paged.totalCount,

--- a/SearchCore/src/commonMain/kotlin/my/drivebit/search/SearchViewModel.kt
+++ b/SearchCore/src/commonMain/kotlin/my/drivebit/search/SearchViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import my.drivebit.network.NetworkException
 import my.drivebit.utils.SearchUrlParts
 import my.drivebit.utils.parseSearchUrl
 
@@ -25,6 +26,33 @@ sealed interface SearchUiState {
         val message: String,
     ) : SearchUiState
 }
+
+internal fun userFacingSearchError(error: Throwable): String {
+    val raw = error.message?.trim().orEmpty()
+    val status = (error as? NetworkException)?.statusCodeValue ?: extractHttpStatusFromMessage(raw)
+    if (isTechnicalSearchError(raw) || raw.isEmpty()) {
+        return when {
+            status != null && status in 500..599 -> SEARCH_SERVER_UNAVAILABLE_MESSAGE
+            status != null && status == 408 -> SEARCH_SERVER_UNAVAILABLE_MESSAGE
+            status != null && status == 429 -> SEARCH_SERVER_UNAVAILABLE_MESSAGE
+            else -> SEARCH_GENERIC_ERROR_MESSAGE
+        }
+    }
+    return raw
+}
+
+private fun isTechnicalSearchError(message: String): Boolean =
+    message.contains("Expected response body of the type", ignoreCase = true) ||
+        message.contains("NoTransformationFoundException", ignoreCase = true) ||
+        message.contains("SourceByteReadChannel", ignoreCase = true) ||
+        message.contains("io.ktor", ignoreCase = true) ||
+        (message.contains("Response status", ignoreCase = true) && message.contains('`'))
+
+private fun extractHttpStatusFromMessage(message: String): Int? =
+    Regex("""Response status `(\d{3})`""").find(message)?.groupValues?.get(1)?.toIntOrNull()
+
+private const val SEARCH_SERVER_UNAVAILABLE_MESSAGE = "Сервер временно недоступен. Попробуйте позже"
+private const val SEARCH_GENERIC_ERROR_MESSAGE = "Не удалось выполнить поиск. Попробуйте позже"
 
 class SearchViewModel(
     private val repositoryFactory: (SearchFilterSet) -> SearchCarRepository,
@@ -49,7 +77,7 @@ class SearchViewModel(
                     _state.value = SearchUiState.Results(filters = filters, result = result)
                 } catch (e: Exception) {
                     if (e is CancellationException) throw e
-                    _state.value = SearchUiState.Error(e.message ?: "Не удалось выполнить поиск")
+                    _state.value = SearchUiState.Error(userFacingSearchError(e))
                 }
             }
     }

--- a/SearchCore/src/commonTest/kotlin/my/drivebit/search/HttpSearchCarsApiTest.kt
+++ b/SearchCore/src/commonTest/kotlin/my/drivebit/search/HttpSearchCarsApiTest.kt
@@ -1,0 +1,54 @@
+package my.drivebit.search
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import my.drivebit.network.NetworkException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class HttpSearchCarsApiTest {
+    @Test
+    fun `searchCars throws NetworkException on 503 without content type`() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = "",
+                        status = HttpStatusCode.ServiceUnavailable,
+                        headers = headersOf(),
+                    )
+                }
+            val api = HttpSearchCarsApi(HttpClient(mockEngine))
+
+            val exception =
+                assertFailsWith<NetworkException> {
+                    api.searchCars(
+                        cityId = "158835",
+                        dateFrom = null,
+                        dateTo = null,
+                        availableMileagePerDayKmMin = null,
+                        dailyPriceMin = null,
+                        dailyPriceMax = null,
+                        yearMin = null,
+                        yearMax = null,
+                        seatsMin = null,
+                        bodyTypes = null,
+                        brandId = 1,
+                        modelId = null,
+                        driveTypes = null,
+                        geoLat = null,
+                        geoLon = null,
+                        radiusKm = null,
+                        page = 1,
+                        pageSize = 9,
+                    )
+                }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, exception.statusCode)
+        }
+}

--- a/SearchCore/src/commonTest/kotlin/my/drivebit/search/SearchViewModelTest.kt
+++ b/SearchCore/src/commonTest/kotlin/my/drivebit/search/SearchViewModelTest.kt
@@ -1,5 +1,6 @@
 package my.drivebit.search
 
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import my.drivebit.network.NetworkException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -74,6 +76,64 @@ class SearchViewModelTest {
 
             val error = assertIs<SearchUiState.Error>(vm.state.value)
             assertEquals("boom", error.message)
+        }
+
+    @Test
+    fun `load url hides technical ktor body transformation errors`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val technical =
+                "Expected response body of the type 'class CarDTOPagedResult' but was " +
+                    "'class SourceByteReadChannel' In response from " +
+                    "`https://drivebit.ru/api/Car/list/filtered/158835?page=1&pageSize=9&BrandId=1` " +
+                    "Response status `503` Response header `ContentType: null`"
+            val vm =
+                SearchViewModel(
+                    repositoryFactory = {
+                        object : SearchCarRepository {
+                            override val results: Flow<SearchCarsResult> =
+                                flow { throw IllegalStateException(technical) }
+                        }
+                    },
+                    brandResolver = { null },
+                    modelResolver = { _, _ -> null },
+                    coroutineScope = CoroutineScope(SupervisorJob() + dispatcher),
+                )
+
+            vm.load("/search/abarth")
+            advanceUntilIdle()
+
+            val error = assertIs<SearchUiState.Error>(vm.state.value)
+            assertEquals("Сервер временно недоступен. Попробуйте позже", error.message)
+        }
+
+    @Test
+    fun `load url maps NetworkException 503 to friendly message`() =
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val vm =
+                SearchViewModel(
+                    repositoryFactory = {
+                        object : SearchCarRepository {
+                            override val results: Flow<SearchCarsResult> =
+                                flow {
+                                    throw NetworkException(
+                                        HttpStatusCode.ServiceUnavailable,
+                                        "",
+                                    )
+                                }
+                        }
+                    },
+                    brandResolver = { null },
+                    modelResolver = { _, _ -> null },
+                    coroutineScope = CoroutineScope(SupervisorJob() + dispatcher),
+                )
+
+            vm.load("/search/abarth")
+            advanceUntilIdle()
+
+            val error = assertIs<SearchUiState.Error>(vm.state.value)
+            assertEquals("Сервер временно недоступен. Попробуйте позже", error.message)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- `HttpSearchCarsApi` uses `parseResponse()` so a 503 without Content-Type no longer throws `NoTransformationFoundException`
- `SearchViewModel` maps technical/5xx errors to «Сервер временно недоступен. Попробуйте позже» instead of raw Ktor text
- Regression tests for both paths

## Test plan
- [x] `./gradlew :SearchCore:testDebugUnitTest --tests 'my.drivebit.search.SearchViewModelTest' --tests 'my.drivebit.search.HttpSearchCarsApiTest'`
- [ ] Open `/search/abarth` after deploy — results load when API is healthy
- [ ] On simulated 503, UI shows friendly Russian message (not Ktor dump)


Made with [Cursor](https://cursor.com)