### PR TITLE
Sync search SEO when filtering by brand

### DIFF
--- a/Utils/src/commonMain/kotlin/my/drivebit/utils/SearchLocationSeo.kt
+++ b/Utils/src/commonMain/kotlin/my/drivebit/utils/SearchLocationSeo.kt
@@ -1,0 +1,15 @@
+package my.drivebit.utils
+
+fun locationPathForSeo(href: String): String =
+    href
+        .substringBefore('?')
+        .substringBefore('#')
+        .removeSuffix("/")
+        .ifEmpty { "/" }
+
+fun commitSearchLocationSeo(
+    locationHref: String,
+    updateMetaForPath: (String) -> Unit,
+) {
+    updateMetaForPath(locationPathForSeo(locationHref))
+}

--- a/Utils/src/commonTest/kotlin/my/drivebit/utils/SearchLocationSeoTest.kt
+++ b/Utils/src/commonTest/kotlin/my/drivebit/utils/SearchLocationSeoTest.kt
@@ -1,0 +1,24 @@
+package my.drivebit.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchLocationSeoTest {
+    @Test
+    fun locationPathForSeo_stripsQueryFragmentAndTrailingSlash() {
+        assertEquals("/search/audi", locationPathForSeo("/search/audi?page=2"))
+        assertEquals("/search/audi", locationPathForSeo("/search/audi/#hash"))
+        assertEquals("/search/audi", locationPathForSeo("/search/audi/"))
+        assertEquals("/moskva/search", locationPathForSeo("/moskva/search"))
+        assertEquals("/", locationPathForSeo("/"))
+    }
+
+    @Test
+    fun commitSearchLocationSeo_invokesUpdaterWithNormalizedBrandPath() {
+        var seen: String? = null
+        commitSearchLocationSeo("/search/audi?foo=1") { path ->
+            seen = path
+        }
+        assertEquals("/search/audi", seen)
+    }
+}

--- a/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
+++ b/searchApp/src/jsMain/kotlin/my/drivebit/search/SearchApp.kt
@@ -33,12 +33,15 @@ import my.drivebit.components.mileageFilterLabelForMin
 import my.drivebit.design.CSSColors
 import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
+import my.drivebit.navigation.MetaTags
 import my.drivebit.utils.cityNameToSlug
+import my.drivebit.utils.commitSearchLocationSeo
 import my.drivebit.utils.parseSearchUrl
 import my.drivebit.utils.resolveBareSearchRedirectPath
 import my.drivebit.utils.uiIndexToUrlPage
 import my.drivebit.utils.urlPageToUiIndex
 import my.drivebit.repositories.MyCityRepository
+import my.drivebit.shared.storage.Storage
 import my.drivebit.web.CitySlugResolver
 import my.drivebit.web.buildCarDetailUrl
 import my.drivebit.web.canonicalSearchBrandPath
@@ -63,6 +66,7 @@ fun SearchApp() {
     val viewModel: SearchViewModel = koinInject()
     val citySlugResolver: CitySlugResolver = koinInject()
     val myCityRepository: MyCityRepository = koinInject()
+    val storage: Storage = koinInject()
     var locationHref by remember { mutableStateOf(currentLocationHref()) }
     val state by viewModel.state.collectAsState()
     var searchCityName by remember { mutableStateOf<String?>(null) }
@@ -107,6 +111,9 @@ fun SearchApp() {
             searchCityName = myCityRepository.getSelectedCity.first().name
         }
         viewModel.load(locationHref)
+        commitSearchLocationSeo(locationHref) { seoPath ->
+            MetaTags.updateForPath(seoPath, storage)
+        }
     }
 
     var lastFilters by remember { mutableStateOf<SearchFilterSet?>(null) }


### PR DESCRIPTION
## Summary
- Fix stale title/description/SEO text after client-side brand filter (e.g. Audi) until full page reload
- Call `MetaTags.updateForPath` from `SearchApp` whenever the search location changes
- Add `commitSearchLocationSeo` helper + unit tests

## Test plan
- [ ] CI green
- [ ] Open `/moskva/search`, pick Audi — title and SEO block update without F5
- [ ] Prod smoke after release


Made with [Cursor](https://cursor.com)