### PR TITLE
Add allowed travel destinations to car create and edit

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditMviViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditMviViewModel.kt
@@ -133,6 +133,10 @@ sealed interface CarEditIntent {
         val apiValue: String?,
     ) : CarEditIntent
 
+    data class ToggleTravelDestination(
+        val name: String,
+    ) : CarEditIntent
+
     data class UpdateDescription(
         val value: String,
     ) : CarEditIntent
@@ -206,6 +210,7 @@ sealed interface CarEditMviState {
         val driveTypes: List<EnumItem> = emptyList(),
         val engineTypes: List<EnumItem> = emptyList(),
         val trunkSizes: List<EnumItem> = emptyList(),
+        val travelDestinations: List<EnumItem> = emptyList(),
         val isBrandFocused: Boolean = false,
         val isModelFocused: Boolean = false,
         val isBodyTypeFocused: Boolean = false,
@@ -253,6 +258,7 @@ class CarEditMviViewModelImpl(
     private val driveTypeViewModel: DriveTypeViewModel,
     private val engineTypeViewModel: EngineTypeViewModel,
     private val trunkSizeViewModel: TrunkSizeViewModel,
+    private val travelDestinationsViewModel: TravelDestinationsViewModel,
     private val carId: String,
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     private val observerCoroutineScope: CoroutineScope? = null,
@@ -282,6 +288,8 @@ class CarEditMviViewModelImpl(
             ) { brands, models, bodyTypes, driveTypes, engineTypes ->
                 CarEditEnumsState(brands, models, bodyTypes, driveTypes, engineTypes)
             }.combine(trunkSizeViewModel.trunkSizes) { enumsState, trunkSizes ->
+                enumsState to trunkSizes
+            }.combine(travelDestinationsViewModel.options) { (enumsState, trunkSizes), travelDestinations ->
                 _state.update { currentState ->
                     when (currentState) {
                         is CarEditMviState.Success -> {
@@ -295,6 +303,7 @@ class CarEditMviViewModelImpl(
                                 driveTypes = enumsState.driveTypes,
                                 engineTypes = enumsState.engineTypes,
                                 trunkSizes = trunkSizes,
+                                travelDestinations = travelDestinations,
                             )
                         }
                         else -> currentState
@@ -451,6 +460,30 @@ class CarEditMviViewModelImpl(
                     )
                 }
             }
+            is CarEditIntent.ToggleTravelDestination -> {
+                updateFormData { form ->
+                    val selected = form.allowedTravelDestinations.toMutableList()
+                    val translates = form.allowedTravelDestinationsTranslate.toMutableList()
+                    val index = selected.indexOf(intent.name)
+                    if (index >= 0) {
+                        selected.removeAt(index)
+                        if (index < translates.size) translates.removeAt(index)
+                    } else {
+                        selected.add(intent.name)
+                        val label =
+                            (_state.value as? CarEditMviState.Success)
+                                ?.travelDestinations
+                                ?.find { it.name == intent.name }
+                                ?.translate
+                                ?: intent.name
+                        translates.add(label)
+                    }
+                    form.copy(
+                        allowedTravelDestinations = selected,
+                        allowedTravelDestinationsTranslate = translates,
+                    )
+                }
+            }
             is CarEditIntent.UpdateDescription -> {
                 updateFormData { it.copy(description = intent.value) }
             }
@@ -504,6 +537,7 @@ class CarEditMviViewModelImpl(
             driveTypeViewModel.loadDriveTypes()
             engineTypeViewModel.loadEngineTypes()
             trunkSizeViewModel.loadTrunkSizes()
+            travelDestinationsViewModel.load()
             runCatching {
                 val car = carService.getCar(carId)
                 val formData = mapToFormData(car)
@@ -596,6 +630,7 @@ class CarEditMviViewModelImpl(
                         insurance = formData.insurance?.trim()?.takeIf { it.isNotEmpty() },
                         ParkingAssistances = emptyList(),
                         MultimediaSystemOptions = emptyList(),
+                        allowedTravelDestinations = formData.allowedTravelDestinations,
                     )
                 carService.createOrUpdateCar(request, carIdToSave)
                 myCarRepository.refresh()
@@ -799,6 +834,8 @@ class CarEditMviViewModelImpl(
             availableMileagePerDayKm = car.availableMileagePerDayKm?.let { NumberFormatter.formatInt(it) } ?: "",
             insurance = car.insurance?.trim()?.takeIf { it.isNotEmpty() },
             insuranceTranslate = car.insuranceTranslate?.trim()?.takeIf { it.isNotEmpty() },
+            allowedTravelDestinations = car.resolvedAllowedTravelDestinations(),
+            allowedTravelDestinationsTranslate = car.resolvedAllowedTravelDestinationsTranslate(),
             photos = car.photos,
         )
 }

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarEditViewModel.kt
@@ -62,6 +62,8 @@ data class CarEditFormData(
     val availableMileagePerDayKm: String = "",
     val insurance: String? = null,
     val insuranceTranslate: String? = null,
+    val allowedTravelDestinations: List<String> = emptyList(),
+    val allowedTravelDestinationsTranslate: List<String> = emptyList(),
     val photos: List<my.drivebit.network.services.CarPhotoItem> = emptyList(),
 )
 
@@ -243,6 +245,8 @@ class CarEditViewModelImpl(
             availableMileagePerDayKm = car.availableMileagePerDayKm?.let { NumberFormatter.formatInt(it) } ?: "",
             insurance = car.insurance?.trim()?.takeIf { it.isNotEmpty() },
             insuranceTranslate = car.insuranceTranslate?.trim()?.takeIf { it.isNotEmpty() },
+            allowedTravelDestinations = car.resolvedAllowedTravelDestinations(),
+            allowedTravelDestinationsTranslate = car.resolvedAllowedTravelDestinationsTranslate(),
             photos = car.photos,
         )
     }
@@ -400,6 +404,7 @@ class CarEditViewModelImpl(
                         insurance = formData.insurance?.trim()?.takeIf { it.isNotEmpty() },
                         ParkingAssistances = emptyList(),
                         MultimediaSystemOptions = emptyList(),
+                        allowedTravelDestinations = formData.allowedTravelDestinations,
                     )
                 carService.createOrUpdateCar(request, formData.carId)
                 val updatedCar = carService.getCar(formData.carId)

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/TravelDestinationsViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/TravelDestinationsViewModel.kt
@@ -1,0 +1,60 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import my.drivebit.repositories.CarEnumsRepository
+import my.drivebit.repositories.EnumItem
+import my.drivebit.repositories.SelectedTravelDestinationsRepository
+
+class TravelDestinationsViewModel(
+    private val carEnumsRepository: CarEnumsRepository,
+    private val selectedTravelDestinationsRepository: SelectedTravelDestinationsRepository,
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    private val _options = MutableStateFlow<List<EnumItem>>(emptyList())
+    val options: StateFlow<List<EnumItem>> = _options.asStateFlow()
+
+    private val _selectedNames = MutableStateFlow<List<String>>(emptyList())
+    val selectedNames: StateFlow<List<String>> = _selectedNames.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun load() {
+        coroutineScope.launch {
+            runCatching {
+                carEnumsRepository.getAllTravelDestinations()
+            }.onSuccess { destinations ->
+                _options.value = destinations
+                _error.value = null
+                val saved = selectedTravelDestinationsRepository.getDestinationNames()
+                if (saved.isNotEmpty()) {
+                    _selectedNames.value = saved
+                }
+            }.onFailure {
+                _error.value = "Не удалось загрузить направления путешествий"
+            }
+        }
+    }
+
+    fun toggle(name: String) {
+        _selectedNames.update { current ->
+            if (name in current) current - name else current + name
+        }
+    }
+
+    fun confirmSelection() {
+        val names = _selectedNames.value
+        val translates =
+            names.mapNotNull { name ->
+                _options.value.find { it.name == name }?.translate
+            }
+        selectedTravelDestinationsRepository.saveDestinations(names, translates)
+    }
+}

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/di/ViewModelsModule.kt
@@ -82,6 +82,7 @@ import my.drivebit.viewmodels.RentViewModelImpl
 import my.drivebit.viewmodels.TelegramLinkViewModel
 import my.drivebit.viewmodels.TelegramLinkViewModelImpl
 import my.drivebit.viewmodels.TrunkSizeViewModel
+import my.drivebit.viewmodels.TravelDestinationsViewModel
 import my.drivebit.viewmodels.UnreadMessagesViewModel
 import my.drivebit.viewmodels.UnreadMessagesViewModelImpl
 import my.drivebit.viewmodels.ValidatorViewModel
@@ -322,6 +323,13 @@ val commonViewModelsModule: Module =
         }
 
         factory {
+            TravelDestinationsViewModel(
+                carEnumsRepository = get(),
+                selectedTravelDestinationsRepository = get(),
+            )
+        }
+
+        factory {
             CityViewModel(
                 cityRepository = get(),
             )
@@ -376,6 +384,7 @@ val commonViewModelsModule: Module =
                 driveTypeViewModel = get(),
                 engineTypeViewModel = get(),
                 trunkSizeViewModel = get(),
+                travelDestinationsViewModel = get(),
                 carId = carId,
             )
         }

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarEditMviViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarEditMviViewModelTest.kt
@@ -787,6 +787,28 @@ class CarEditMviViewModelTest {
         }
 
     @Test
+    fun `SaveCar should send allowedTravelDestinations selected in form`() =
+        runTest(StandardTestDispatcher()) {
+            val mockCarService = MockCarServiceForMvi()
+            val viewModel = createCarEditMviViewModel(carService = mockCarService, carId = "test-car-id")
+
+            advanceUntilIdle()
+            viewModel.handleIntent(CarEditIntent.UpdateLicensePlate("А123ВЕ12"))
+            advanceUntilIdle()
+            viewModel.handleIntent(CarEditIntent.ToggleTravelDestination("Belarus"))
+            advanceUntilIdle()
+            viewModel.handleIntent(CarEditIntent.ToggleTravelDestination("Crimea"))
+            advanceUntilIdle()
+            viewModel.handleIntent(CarEditIntent.SaveCar)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("Belarus", "Crimea"),
+                mockCarService.lastCreateOrUpdateRequest?.allowedTravelDestinations,
+            )
+        }
+
+    @Test
     fun `UpdateEngineVolume should update form data and set hasChanges to true`() =
         runTest(StandardTestDispatcher()) {
             val viewModel = createCarEditMviViewModel(carId = "")
@@ -1136,6 +1158,8 @@ fun createMockCarEnumsRepository(): my.drivebit.repositories.CarEnumsRepository 
 
         override suspend fun getAllTrunkSizes(): List<my.drivebit.repositories.EnumItem> = emptyList()
 
+        override suspend fun getAllTravelDestinations(): List<my.drivebit.repositories.EnumItem> = emptyList()
+
         override suspend fun getAllDocumentTypes(): List<my.drivebit.repositories.EnumItem> = emptyList()
     }
 
@@ -1196,6 +1220,24 @@ fun TestScope.createCarEditMviViewModel(
             driveTypeViewModel = driveTypeViewModel ?: createMockDriveTypeViewModel(coroutineScope = viewModelScope),
             engineTypeViewModel = engineTypeViewModel ?: createMockEngineTypeViewModel(coroutineScope = viewModelScope),
             trunkSizeViewModel = trunkSizeViewModel ?: createMockTrunkSizeViewModel(coroutineScope = viewModelScope),
+            travelDestinationsViewModel =
+                TravelDestinationsViewModel(
+                    carEnumsRepository = createMockCarEnumsRepository(),
+                    selectedTravelDestinationsRepository =
+                        object : my.drivebit.repositories.SelectedTravelDestinationsRepository {
+                            override fun saveDestinations(
+                                names: List<String>,
+                                translates: List<String>,
+                            ) = Unit
+
+                            override fun getDestinationNames(): List<String> = emptyList()
+
+                            override fun getDestinationTranslates(): List<String> = emptyList()
+
+                            override fun clearDestinations() = Unit
+                        },
+                    coroutineScope = viewModelScope,
+                ),
             myCarRepository = myCarRepository,
             carId = carId,
             coroutineScope = viewModelScope,

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarEditViewModelMappingTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarEditViewModelMappingTest.kt
@@ -78,6 +78,27 @@ class CarEditViewModelMappingTest {
             assertEquals("Test Address", formData.address)
             assertEquals(1, formData.photos.size)
             assertEquals("https://example.com/photo.jpg", formData.photos[0].url)
+            assertEquals(emptyList(), formData.allowedTravelDestinations)
+        }
+
+    @Test
+    fun `toFormData should map equipment allowedTravelDestinations`() =
+        runTest(StandardTestDispatcher()) {
+            val carResponse =
+                CarDetailResponse(
+                    id = "car-1",
+                    equipment =
+                        my.drivebit.network.services.CarEquipment(
+                            allowedTravelDestinations = listOf("Belarus", "Abkhazia"),
+                            allowedTravelDestinationsTranslate = listOf("Беларусь", "Абхазия"),
+                        ),
+                )
+
+            val viewModel = CarEditViewModelImpl(MockCarServiceForEdit())
+            val formData = viewModel.mapToFormData(carResponse)
+
+            assertEquals(listOf("Belarus", "Abkhazia"), formData.allowedTravelDestinations)
+            assertEquals(listOf("Беларусь", "Абхазия"), formData.allowedTravelDestinationsTranslate)
         }
 
     @Test

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/TravelDestinationsViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/TravelDestinationsViewModelTest.kt
@@ -1,0 +1,106 @@
+package my.drivebit.viewmodels
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import my.drivebit.repositories.EnumItem
+import my.drivebit.repositories.SelectedTravelDestinationsRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TravelDestinationsViewModelTest {
+    @Test
+    fun `load exposes travel destinations from enums repository`() =
+        runTest(StandardTestDispatcher()) {
+            val enums =
+                object : FakeCarEnumsForTravel() {
+                    override suspend fun getAllTravelDestinations(): List<EnumItem> =
+                        listOf(
+                            EnumItem(1, "Belarus", "Беларусь"),
+                            EnumItem(2, "Crimea", "В Крым"),
+                        )
+                }
+            val selected = FakeSelectedTravelDestinations()
+            val viewModel = TravelDestinationsViewModel(enums, selected, this)
+
+            viewModel.load()
+            advanceUntilIdle()
+
+            assertEquals(2, viewModel.options.value.size)
+            assertEquals("Belarus", viewModel.options.value[0].name)
+        }
+
+    @Test
+    fun `toggle and confirmSelection persist selected names`() =
+        runTest(StandardTestDispatcher()) {
+            val enums =
+                object : FakeCarEnumsForTravel() {
+                    override suspend fun getAllTravelDestinations(): List<EnumItem> =
+                        listOf(
+                            EnumItem(1, "Belarus", "Беларусь"),
+                            EnumItem(3, "Abkhazia", "Абхазия"),
+                        )
+                }
+            val selected = FakeSelectedTravelDestinations()
+            val viewModel = TravelDestinationsViewModel(enums, selected, this)
+
+            viewModel.load()
+            advanceUntilIdle()
+            viewModel.toggle("Belarus")
+            viewModel.toggle("Abkhazia")
+            viewModel.toggle("Belarus")
+            viewModel.confirmSelection()
+
+            assertEquals(listOf("Abkhazia"), selected.getDestinationNames())
+            assertEquals(listOf("Абхазия"), selected.getDestinationTranslates())
+            assertEquals(listOf("Abkhazia"), viewModel.selectedNames.value)
+        }
+
+    @Test
+    fun `load restores previously saved destinations`() =
+        runTest(StandardTestDispatcher()) {
+            val enums =
+                object : FakeCarEnumsForTravel() {
+                    override suspend fun getAllTravelDestinations(): List<EnumItem> =
+                        listOf(EnumItem(2, "Crimea", "В Крым"))
+                }
+            val selected =
+                FakeSelectedTravelDestinations().apply {
+                    saveDestinations(listOf("Crimea"), listOf("В Крым"))
+                }
+            val viewModel = TravelDestinationsViewModel(enums, selected, this)
+
+            viewModel.load()
+            advanceUntilIdle()
+
+            assertEquals(listOf("Crimea"), viewModel.selectedNames.value)
+            assertTrue(viewModel.error.value == null)
+        }
+}
+
+private open class FakeCarEnumsForTravel : my.drivebit.repositories.CarEnumsRepository by createMockCarEnumsRepository()
+
+private class FakeSelectedTravelDestinations : SelectedTravelDestinationsRepository {
+    private var names: List<String> = emptyList()
+    private var translates: List<String> = emptyList()
+
+    override fun saveDestinations(
+        names: List<String>,
+        translates: List<String>,
+    ) {
+        this.names = names
+        this.translates = translates
+    }
+
+    override fun getDestinationNames(): List<String> = names
+
+    override fun getDestinationTranslates(): List<String> = translates
+
+    override fun clearDestinations() {
+        names = emptyList()
+        translates = emptyList()
+    }
+}

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarTravelDestinationsField.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarTravelDestinationsField.kt
@@ -1,0 +1,66 @@
+package my.drivebit.components
+
+import androidx.compose.runtime.Composable
+import my.drivebit.design.CSSColors
+import my.drivebit.design.CSSTypography
+import my.drivebit.design.applyTypography
+import my.drivebit.repositories.EnumItem
+import org.jetbrains.compose.web.attributes.InputType
+import org.jetbrains.compose.web.attributes.checked
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Input
+import org.jetbrains.compose.web.dom.Label
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun CarTravelDestinationsField(
+    options: List<EnumItem>,
+    selectedNames: List<String>,
+    onToggle: (String) -> Unit,
+) {
+    Column(gap = 12.px) {
+        Span({
+            style {
+                applyTypography(CSSTypography.Styles.body)
+                fontSize(CSSTypography.FontSize.sm)
+                fontWeight(CSSTypography.FontWeight.medium)
+                color(CSSColors.Black)
+            }
+        }) {
+            Text("Направления путешествий")
+        }
+        Div({
+            style {
+                display(DisplayStyle.Flex)
+                flexDirection(FlexDirection.Column)
+                gap(8.px)
+            }
+        }) {
+            options.forEach { option ->
+                Label({
+                    style {
+                        display(DisplayStyle.Flex)
+                        alignItems(AlignItems.Center)
+                        gap(8.px)
+                        cursor("pointer")
+                    }
+                }) {
+                    Input(InputType.Checkbox) {
+                        checked(option.name in selectedNames)
+                        onChange { onToggle(option.name) }
+                    }
+                    Span({
+                        style {
+                            applyTypography(CSSTypography.Styles.body)
+                            color(CSSColors.Black)
+                        }
+                    }) {
+                        Text(option.translate)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarTravelDestinationsField.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/CarTravelDestinationsField.kt
@@ -6,7 +6,6 @@ import my.drivebit.design.CSSTypography
 import my.drivebit.design.applyTypography
 import my.drivebit.repositories.EnumItem
 import org.jetbrains.compose.web.attributes.InputType
-import org.jetbrains.compose.web.attributes.checked
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Input
@@ -39,24 +38,40 @@ fun CarTravelDestinationsField(
             }
         }) {
             options.forEach { option ->
-                Label({
+                val checkboxId = "travel-destination-${option.name}"
+                Div({
                     style {
                         display(DisplayStyle.Flex)
                         alignItems(AlignItems.Center)
                         gap(8.px)
-                        cursor("pointer")
                     }
                 }) {
-                    Input(InputType.Checkbox) {
-                        checked(option.name in selectedNames)
-                        onChange { onToggle(option.name) }
-                    }
-                    Span({
-                        style {
-                            applyTypography(CSSTypography.Styles.body)
-                            color(CSSColors.Black)
-                        }
-                    }) {
+                    Input(
+                        type = InputType.Checkbox,
+                        attrs = {
+                            id(checkboxId)
+                            checked(option.name in selectedNames)
+                            onInput {
+                                onToggle(option.name)
+                            }
+                            style {
+                                width(20.px)
+                                height(20.px)
+                                cursor("pointer")
+                                flexShrink(0)
+                            }
+                        },
+                    )
+                    Label(
+                        forId = checkboxId,
+                        attrs = {
+                            style {
+                                cursor("pointer")
+                                applyTypography(CSSTypography.Styles.body)
+                                color(CSSColors.Black)
+                            }
+                        },
+                    ) {
                         Text(option.translate)
                     }
                 }

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarEditPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import kotlinx.browser.window
 import my.drivebit.components.ActionButton
 import my.drivebit.components.CarInsuranceSelectField
+import my.drivebit.components.CarTravelDestinationsField
 import my.drivebit.components.CenteredFormContainer
 import my.drivebit.components.Column
 import my.drivebit.components.FormSection
@@ -461,6 +462,12 @@ fun CarEditPage() {
                                 insurance = formData.insurance,
                                 insuranceTranslate = formData.insuranceTranslate,
                                 onSelect = { viewModel.handleIntent(CarEditIntent.SelectInsurance(it)) },
+                            )
+
+                            CarTravelDestinationsField(
+                                options = currentState.travelDestinations,
+                                selectedNames = formData.allowedTravelDestinations,
+                                onToggle = { viewModel.handleIntent(CarEditIntent.ToggleTravelDestination(it)) },
                             )
 
                             CarStsDocumentsSection(carId = currentState.carId)

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/TravelDestinationsSelectionPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/TravelDestinationsSelectionPage.kt
@@ -12,6 +12,7 @@ import my.drivebit.components.FormSection
 import my.drivebit.components.TextError
 import my.drivebit.components.TextSmallBodyBlack
 import my.drivebit.components.ToolbarBackArrow
+import my.drivebit.design.CSSColors
 import my.drivebit.shell.PageWithLogo
 import my.drivebit.viewmodels.ButtonState
 import my.drivebit.viewmodels.TravelDestinationsViewModel
@@ -56,6 +57,7 @@ fun TravelDestinationsSelectionPage(
 
             ButtonContainer(id = "travel-destinations-continue") {
                 ActionButton(
+                    enabledColor = CSSColors.Blue,
                     text = "Далее",
                     viewModel = continueButtonViewModel,
                     onClick = {

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/TravelDestinationsSelectionPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/TravelDestinationsSelectionPage.kt
@@ -1,0 +1,69 @@
+package my.drivebit.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import my.drivebit.components.ActionButton
+import my.drivebit.components.ButtonContainer
+import my.drivebit.components.CarTravelDestinationsField
+import my.drivebit.components.CenteredFormContainer
+import my.drivebit.components.FormSection
+import my.drivebit.components.TextError
+import my.drivebit.components.TextSmallBodyBlack
+import my.drivebit.components.ToolbarBackArrow
+import my.drivebit.shell.PageWithLogo
+import my.drivebit.viewmodels.ButtonState
+import my.drivebit.viewmodels.TravelDestinationsViewModel
+import my.drivebit.viewmodels.createButtonViewModel
+import org.koin.compose.koinInject
+
+@Composable
+fun TravelDestinationsSelectionPage(
+    onContinue: () -> Unit = {},
+    onBack: () -> Unit = {},
+) {
+    val viewModel: TravelDestinationsViewModel = koinInject()
+    val options by viewModel.options.collectAsState()
+    val selectedNames by viewModel.selectedNames.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val continueButtonViewModel = createButtonViewModel()
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
+        continueButtonViewModel.setState(ButtonState.Enabled)
+    }
+
+    PageWithLogo {
+        CenteredFormContainer {
+            ToolbarBackArrow(
+                title = "Направления путешествий",
+                onBackClick = onBack,
+            )
+
+            FormSection {
+                TextSmallBodyBlack("Можно выбрать несколько направлений или пропустить")
+                if (error != null) {
+                    TextError(error ?: "Произошла ошибка")
+                } else {
+                    CarTravelDestinationsField(
+                        options = options,
+                        selectedNames = selectedNames,
+                        onToggle = { viewModel.toggle(it) },
+                    )
+                }
+            }
+
+            ButtonContainer(id = "travel-destinations-continue") {
+                ActionButton(
+                    text = "Далее",
+                    viewModel = continueButtonViewModel,
+                    onClick = {
+                        viewModel.confirmSelection()
+                        onContinue()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
@@ -155,6 +155,7 @@ data class CarDetailResponse(
     val chassis: CarChassis? = null,
     val body: CarBody? = null,
     val trunk: CarTrunk? = null,
+    val equipment: CarEquipment? = null,
     val photos: List<CarPhotoItem> = emptyList(),
     val brandId: Int? = null,
     val brandName: String? = null,
@@ -213,6 +214,12 @@ data class CarDetailResponse(
     fun resolvedTrunkSize(): String? = trunk?.trunkSize
 
     fun resolvedTrunkSizeTranslate(): String? = trunk?.trunkSizeTranslate
+
+    fun resolvedAllowedTravelDestinations(): List<String> =
+        equipment?.allowedTravelDestinations.orEmpty()
+
+    fun resolvedAllowedTravelDestinationsTranslate(): List<String> =
+        equipment?.allowedTravelDestinationsTranslate.orEmpty()
 
     fun resolvedBrandId(): Int? = brandId
 
@@ -317,6 +324,12 @@ data class CarTrunk(
 )
 
 @Serializable
+data class CarEquipment(
+    val allowedTravelDestinations: List<String> = emptyList(),
+    val allowedTravelDestinationsTranslate: List<String> = emptyList(),
+)
+
+@Serializable
 data class CarAddress(
     val postalCode: String? = null,
     val region: String? = null,
@@ -385,6 +398,7 @@ data class CarCreateRequest(
     val insurance: String? = null,
     @SerialName("parkingAssistances") val ParkingAssistances: List<Int> = emptyList(),
     @SerialName("multimediaSystemOptions") val MultimediaSystemOptions: List<Int> = emptyList(),
+    val allowedTravelDestinations: List<String> = emptyList(),
 )
 
 @Serializable
@@ -424,6 +438,7 @@ data class UpdateCarRequest(
     val color: String? = null,
     @SerialName("parkingAssistances") val parkingAssistances: List<String>? = null,
     @SerialName("multimediaSystemOptions") val multimediaSystemOptions: List<String>? = null,
+    val allowedTravelDestinations: List<String>? = null,
 )
 
 fun CarCreateRequest.toUpdateCarRequest(resolvedCarId: String): UpdateCarRequest =
@@ -448,6 +463,7 @@ fun CarCreateRequest.toUpdateCarRequest(resolvedCarId: String): UpdateCarRequest
         engineType = engineType,
         driveType = driveType,
         trunkSize = trunkSize,
+        allowedTravelDestinations = allowedTravelDestinations.takeIf { it.isNotEmpty() },
     )
 
 @Serializable

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Dictionary.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Dictionary.kt
@@ -73,6 +73,7 @@ data class CarEnumsResponse(
     val MultimediaSystemOptionsEnum: List<EnumItem>,
     val ParkingAssistancesEnum: List<EnumItem>,
     val TrunkSizeEnum: List<EnumItem>,
+    val TravelDestinationEnum: List<EnumItem> = emptyList(),
     val DocumentTypeEnum: List<EnumItem>? = null,
 )
 

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
@@ -321,4 +321,56 @@ class CarDetailResponseTest {
             )
         assertNull(car.resolvedInsuranceDisplay())
     }
+
+    @Test
+    fun `getCar should deserialize equipment allowedTravelDestinations`() =
+        runTest {
+            val successResponse =
+                """
+                {
+                    "id": "22e09ade-47b3-45da-9195-d0b382a88fee",
+                    "general": {
+                        "brandName": "BMW",
+                        "modelName": "X5",
+                        "year": 2020,
+                        "licensePlate": "A123BC",
+                        "vin": "",
+                        "seats": 5,
+                        "address": { "geoLat": 55.0, "geoLon": 37.0 }
+                    },
+                    "equipment": {
+                        "allowedTravelDestinations": ["Belarus", "Crimea"],
+                        "allowedTravelDestinationsTranslate": ["Беларусь", "В Крым"]
+                    }
+                }
+                """.trimIndent()
+
+            val mockEngine =
+                MockEngine {
+                    respond(
+                        content = successResponse,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+
+            val httpClient =
+                HttpClient(mockEngine) {
+                    install(ContentNegotiation) {
+                        json(
+                            Json {
+                                ignoreUnknownKeys = true
+                                isLenient = true
+                                encodeDefaults = false
+                            },
+                        )
+                    }
+                }
+
+            val response = httpClient.get("https://drivebit.ru/api/Car/test-id")
+            val result: CarDetailResponse = response.parseResponse()
+
+            assertEquals(listOf("Belarus", "Crimea"), result.resolvedAllowedTravelDestinations())
+            assertEquals(listOf("Беларусь", "В Крым"), result.resolvedAllowedTravelDestinationsTranslate())
+        }
 }

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/CarUpdateRequestTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/CarUpdateRequestTest.kt
@@ -81,4 +81,26 @@ class CarUpdateRequestTest {
         val json = defaultJson.encodeToString(UpdateCarRequest.serializer(), updateRequest)
         assertFalse(json.contains("insurance"))
     }
+
+    @Test
+    fun `toUpdateCarRequest maps allowedTravelDestinations enum names`() {
+        val carId = "d5edee76-d7d7-42bd-be61-bfc3a73786c8"
+        val createRequest =
+            CarCreateRequest(
+                year = 2015,
+                allowedTravelDestinations = listOf("Belarus", "Abkhazia"),
+            )
+
+        val updateRequest = createRequest.toUpdateCarRequest(carId)
+
+        assertEquals(listOf("Belarus", "Abkhazia"), updateRequest.allowedTravelDestinations)
+        val updateJson = defaultJson.encodeToString(UpdateCarRequest.serializer(), updateRequest)
+        assertTrue(updateJson.contains("\"allowedTravelDestinations\""))
+        assertTrue(updateJson.contains("Belarus"))
+        assertTrue(updateJson.contains("Abkhazia"))
+
+        val createJson = defaultJson.encodeToString(CarCreateRequest.serializer(), createRequest)
+        assertTrue(createJson.contains("\"allowedTravelDestinations\""))
+        assertTrue(createJson.contains("Belarus"))
+    }
 }

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CarEnumsHelper.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CarEnumsHelper.kt
@@ -33,6 +33,9 @@ class CarEnumsHelper(
 
     suspend fun getAllTrunkSizes(useTranslation: Boolean = true): List<EnumItem> = repository.getAllTrunkSizes()
 
+    suspend fun getAllTravelDestinations(useTranslation: Boolean = true): List<EnumItem> =
+        repository.getAllTravelDestinations()
+
     suspend fun refreshEnums() {
         repository.getEnums()
     }

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CarEnumsRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CarEnumsRepository.kt
@@ -41,6 +41,8 @@ interface CarEnumsRepository {
 
     suspend fun getAllTrunkSizes(): List<EnumItem>
 
+    suspend fun getAllTravelDestinations(): List<EnumItem>
+
     suspend fun getAllDocumentTypes(): List<EnumItem>
 }
 
@@ -156,6 +158,11 @@ class CarEnumsRepositoryImpl(
     override suspend fun getAllTrunkSizes(): List<EnumItem> {
         val enums = getEnums()
         return enums.TrunkSizeEnum.map { it.toEnumItem() }
+    }
+
+    override suspend fun getAllTravelDestinations(): List<EnumItem> {
+        val enums = getEnums()
+        return enums.TravelDestinationEnum.map { it.toEnumItem() }
     }
 
     override suspend fun getAllDocumentTypes(): List<EnumItem> =

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CreateCarRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/CreateCarRepository.kt
@@ -17,6 +17,7 @@ internal class CreateCarRepositoryImpl(
     private val selectedDriveTypeRepository: SelectedDriveTypeRepository,
     private val selectedEngineTypeRepository: SelectedEngineTypeRepository,
     private val selectedTrunkSizeRepository: SelectedTrunkSizeRepository,
+    private val selectedTravelDestinationsRepository: SelectedTravelDestinationsRepository,
     private val licensePlateRepository: LicensePlateRepository,
     private val selectedAddressRepository: SelectedAddressRepository,
     private val selectedCityRepository: SelectedCityRepository,
@@ -63,6 +64,7 @@ internal class CreateCarRepositoryImpl(
                     prepaymentPercent = DEFAULT_CAR_PREPAYMENT_PERCENT,
                     ParkingAssistances = emptyList(),
                     MultimediaSystemOptions = emptyList(),
+                    allowedTravelDestinations = selectedTravelDestinationsRepository.getDestinationNames(),
                 )
 
             // Выбор города при создании машины отключён: город вводится вместе с адресом, cityId = null

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/SelectedTravelDestinationsRepository.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/SelectedTravelDestinationsRepository.kt
@@ -1,0 +1,48 @@
+package my.drivebit.repositories
+
+import com.russhwolf.settings.Settings
+
+interface SelectedTravelDestinationsRepository {
+    fun saveDestinations(
+        names: List<String>,
+        translates: List<String>,
+    )
+
+    fun getDestinationNames(): List<String>
+
+    fun getDestinationTranslates(): List<String>
+
+    fun clearDestinations()
+}
+
+internal class SelectedTravelDestinationsRepositoryImpl(
+    private val settings: Settings,
+) : SelectedTravelDestinationsRepository {
+    companion object {
+        private const val NAMES_KEY = "selected_travel_destination_names"
+        private const val TRANSLATES_KEY = "selected_travel_destination_translates"
+        private const val SEPARATOR = "\u001f"
+    }
+
+    override fun saveDestinations(
+        names: List<String>,
+        translates: List<String>,
+    ) {
+        settings.putString(NAMES_KEY, names.joinToString(SEPARATOR))
+        settings.putString(TRANSLATES_KEY, translates.joinToString(SEPARATOR))
+    }
+
+    override fun getDestinationNames(): List<String> = decodeList(NAMES_KEY)
+
+    override fun getDestinationTranslates(): List<String> = decodeList(TRANSLATES_KEY)
+
+    override fun clearDestinations() {
+        settings.remove(NAMES_KEY)
+        settings.remove(TRANSLATES_KEY)
+    }
+
+    private fun decodeList(key: String): List<String> {
+        val raw = settings.getStringOrNull(key)?.takeIf { it.isNotEmpty() } ?: return emptyList()
+        return raw.split(SEPARATOR).filter { it.isNotEmpty() }
+    }
+}

--- a/Repositories/src/commonMain/kotlin/my/drivebit/repositories/di/RepositoriesModule.kt
+++ b/Repositories/src/commonMain/kotlin/my/drivebit/repositories/di/RepositoriesModule.kt
@@ -59,6 +59,8 @@ import my.drivebit.repositories.SelectedEngineTypeRepository
 import my.drivebit.repositories.SelectedEngineTypeRepositoryImpl
 import my.drivebit.repositories.SelectedTrunkSizeRepository
 import my.drivebit.repositories.SelectedTrunkSizeRepositoryImpl
+import my.drivebit.repositories.SelectedTravelDestinationsRepository
+import my.drivebit.repositories.SelectedTravelDestinationsRepositoryImpl
 import my.drivebit.repositories.VerifyOtpRepositoryImpl
 import my.drivebit.repositories.WinCodeRepository
 import my.drivebit.repositories.WinCodeRepositoryImpl
@@ -210,6 +212,12 @@ val repositoriesModule: Module =
             )
         }
 
+        single<SelectedTravelDestinationsRepository> {
+            SelectedTravelDestinationsRepositoryImpl(
+                settings = get(),
+            )
+        }
+
         single<CarDataRepository> {
             CarDataRepositoryImpl(
                 settings = get(),
@@ -287,6 +295,7 @@ val repositoriesModule: Module =
                 selectedDriveTypeRepository = get(),
                 selectedEngineTypeRepository = get(),
                 selectedTrunkSizeRepository = get(),
+                selectedTravelDestinationsRepository = get(),
                 licensePlateRepository = get(),
                 selectedAddressRepository = get(),
                 selectedCityRepository = get(),

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/CarEnumsRepositoryTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/CarEnumsRepositoryTest.kt
@@ -122,6 +122,39 @@ class CarEnumsRepositoryTest {
             assertEquals("Седан", result.translate)
         }
 
+    @Test
+    fun `should get all travel destinations when present`() =
+        runTest {
+            val enums =
+                createValidEnums().copy(
+                    TravelDestinationEnum =
+                        listOf(
+                            NetworkEnumItem(1, "Belarus", "Беларусь"),
+                            NetworkEnumItem(2, "Crimea", "В Крым"),
+                        ),
+                )
+            val fakeDictionary = createFakeDictionary(enums)
+            val repository = CarEnumsRepositoryImpl(fakeDictionary)
+
+            val result = repository.getAllTravelDestinations()
+
+            assertEquals(2, result.size)
+            assertEquals("Belarus", result[0].name)
+            assertEquals("Беларусь", result[0].translate)
+        }
+
+    @Test
+    fun `should return empty travel destinations when enum missing`() =
+        runTest {
+            val enums = createValidEnums().copy(TravelDestinationEnum = emptyList())
+            val fakeDictionary = createFakeDictionary(enums)
+            val repository = CarEnumsRepositoryImpl(fakeDictionary)
+
+            val result = repository.getAllTravelDestinations()
+
+            assertTrue(result.isEmpty())
+        }
+
     private fun createFakeDictionary(enums: CarEnumsResponse): Dictionary =
         object : Dictionary {
             override suspend fun getCarEnums(): CarEnumsResponse = enums

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/HasPassportRepoTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/HasPassportRepoTest.kt
@@ -66,6 +66,8 @@ private class FakeCarEnumsRepository : CarEnumsRepository {
     override suspend fun getAllDriveTypes(): List<EnumItem> = throw NotImplementedError()
 
     override suspend fun getAllTrunkSizes(): List<EnumItem> = throw NotImplementedError()
+
+    override suspend fun getAllTravelDestinations(): List<EnumItem> = throw NotImplementedError()
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/Repositories/src/commonTest/kotlin/my/drivebit/repositories/SelectedTravelDestinationsRepositoryTest.kt
+++ b/Repositories/src/commonTest/kotlin/my/drivebit/repositories/SelectedTravelDestinationsRepositoryTest.kt
@@ -1,0 +1,43 @@
+package my.drivebit.repositories
+
+import my.drivebit.shared.storage.InMemorySettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SelectedTravelDestinationsRepositoryTest {
+    @Test
+    fun `save and get destinations preserves names and translates`() {
+        val repository = SelectedTravelDestinationsRepositoryImpl(InMemorySettings())
+
+        repository.saveDestinations(
+            names = listOf("Belarus", "Crimea"),
+            translates = listOf("Беларусь", "В Крым"),
+        )
+
+        assertEquals(listOf("Belarus", "Crimea"), repository.getDestinationNames())
+        assertEquals(listOf("Беларусь", "В Крым"), repository.getDestinationTranslates())
+    }
+
+    @Test
+    fun `get destinations returns empty when nothing saved`() {
+        val repository = SelectedTravelDestinationsRepositoryImpl(InMemorySettings())
+
+        assertTrue(repository.getDestinationNames().isEmpty())
+        assertTrue(repository.getDestinationTranslates().isEmpty())
+    }
+
+    @Test
+    fun `clear destinations removes saved values`() {
+        val repository = SelectedTravelDestinationsRepositoryImpl(InMemorySettings())
+        repository.saveDestinations(
+            names = listOf("Abkhazia"),
+            translates = listOf("Абхазия"),
+        )
+
+        repository.clearDestinations()
+
+        assertTrue(repository.getDestinationNames().isEmpty())
+        assertTrue(repository.getDestinationTranslates().isEmpty())
+    }
+}

--- a/WebShell/src/jsMain/kotlin/my/drivebit/navigation/OwnerCarBundlePaths.kt
+++ b/WebShell/src/jsMain/kotlin/my/drivebit/navigation/OwnerCarBundlePaths.kt
@@ -20,6 +20,7 @@ fun isOwnerCarBundlePath(path: String): Boolean =
         path.startsWith("/production-year-input") ||
         path.startsWith("/seats-count-input") ||
         path.startsWith("/trunk-size-selection") ||
+        path.startsWith("/travel-destinations-selection") ||
         path.startsWith("/daily-rate-input") ||
         path.startsWith("/description-input") ||
         path.startsWith("/passport-upload")
@@ -45,6 +46,7 @@ val ownerCarBundleShellRoutes: List<String> =
         "production-year-input",
         "seats-count-input",
         "trunk-size-selection",
+        "travel-destinations-selection",
         "daily-rate-input",
         "description-input",
         "passport-upload",

--- a/WebShell/src/jsMain/kotlin/my/drivebit/web/CitySlugParsing.kt
+++ b/WebShell/src/jsMain/kotlin/my/drivebit/web/CitySlugParsing.kt
@@ -58,6 +58,7 @@ val RESERVED_FIRST_SEGMENTS: Set<String> =
         "production-year-input",
         "seats-count-input",
         "trunk-size-selection",
+        "travel-destinations-selection",
         "daily-rate-input",
         "description-input",
         "passport-upload",

--- a/myCarsApp/build.gradle.kts
+++ b/myCarsApp/build.gradle.kts
@@ -68,6 +68,7 @@ val ownerCarShellRoutes =
         "production-year-input",
         "seats-count-input",
         "trunk-size-selection",
+        "travel-destinations-selection",
         "daily-rate-input",
         "description-input",
         "passport-upload",

--- a/myCarsApp/src/jsMain/kotlin/my/drivebit/clients/OwnerCarAppContent.kt
+++ b/myCarsApp/src/jsMain/kotlin/my/drivebit/clients/OwnerCarAppContent.kt
@@ -25,6 +25,7 @@ import my.drivebit.screens.PassportUploadPage
 import my.drivebit.screens.ProductionYearInputPage
 import my.drivebit.screens.SeatsCountInputPage
 import my.drivebit.screens.TrunkSizeSelectionPage
+import my.drivebit.screens.TravelDestinationsSelectionPage
 import my.drivebit.shared.storage.Storage
 import my.drivebit.web.homePathHref
 
@@ -172,10 +173,20 @@ internal fun OwnerCarAppContent(
         currentPath.startsWith("/trunk-size-selection") -> {
             TrunkSizeSelectionPage(
                 onTrunkSizeSelected = {
-                    window.location.href = "/description-input"
+                    window.location.href = "/travel-destinations-selection"
                 },
                 onBack = {
                     window.location.href = "/seats-count-input"
+                },
+            )
+        }
+        currentPath.startsWith("/travel-destinations-selection") -> {
+            TravelDestinationsSelectionPage(
+                onContinue = {
+                    window.location.href = "/description-input"
+                },
+                onBack = {
+                    window.location.href = "/trunk-size-selection"
                 },
             )
         }
@@ -195,7 +206,7 @@ internal fun OwnerCarAppContent(
                     window.location.href = "/daily-rate-input"
                 },
                 onBack = {
-                    window.location.href = "/trunk-size-selection"
+                    window.location.href = "/travel-destinations-selection"
                 },
             )
         }


### PR DESCRIPTION
## Summary
- Owners can select travel destinations (Belarus, Crimea, Abkhazia) when creating a car and when editing it
- Wired through Network DTOs, CarEnums, CreateCarRepository, and web wizard/edit UI

## Test plan
- [ ] CI green on this PR
- [ ] Create car wizard shows destinations step after trunk size
- [ ] Car edit page shows destination checkboxes and saves selection

Made with [Cursor](https://cursor.com)