### PR TITLE
Fix travel-destinations-selection Pages 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,12 +85,23 @@ jobs:
         MYCARS="myCarsApp/build/dist/js/productionExecutable"
         cp "$MYCARS/myCars.js" "$DIST/"
         cp "$MYCARS/myCars.js.map" "$DIST/" 2>/dev/null || true
-        for route in create-car my-cars car-edit address-input car-sts-upload passport-upload city-selection; do
+        for route in \
+          create-car my-cars car-edit car-photos-upload car-photos car-availability \
+          city-selection address-input car-sts-upload license-plate-input \
+          car-brand-selection car-model-selection body-type-selection \
+          drive-type-selection engine-type-selection engine-volume-input \
+          production-year-input seats-count-input trunk-size-selection \
+          travel-destinations-selection daily-rate-input description-input \
+          passport-upload
+        do
           if [ -d "$MYCARS/$route" ]; then
             cp -r "$MYCARS/$route" "$DIST/"
           fi
         done
-        for route in create-car my-cars car-edit address-input car-sts-upload passport-upload city-selection; do
+        for route in \
+          create-car my-cars car-edit address-input car-sts-upload passport-upload \
+          city-selection travel-destinations-selection trunk-size-selection
+        do
           test -f "$DIST/$route/index.html"
         done
         test -f "$DIST/myCars.js"

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -59,6 +59,21 @@ jobs:
         cp -r "$MYCARS/my-cars" "$DIST/"
         test -f "$DIST/my-cars/index.html"
         test -f "$DIST/myCars.js"
+        # Owner create/edit shell routes live in myCarsApp dist; keep Pages in sync.
+        for route in \
+          create-car car-edit car-photos-upload car-photos car-availability \
+          city-selection address-input car-sts-upload license-plate-input \
+          car-brand-selection car-model-selection body-type-selection \
+          drive-type-selection engine-type-selection engine-volume-input \
+          production-year-input seats-count-input trunk-size-selection \
+          travel-destinations-selection daily-rate-input description-input \
+          passport-upload
+        do
+          if [ -d "$MYCARS/$route" ]; then
+            cp -r "$MYCARS/$route" "$DIST/"
+          fi
+        done
+        test -f "$DIST/travel-destinations-selection/index.html"
         CHATS="chatsApp/build/dist/js/productionExecutable"
         cp "$CHATS/chats.js" "$DIST/"
         cp -r "$CHATS/chats" "$DIST/"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -250,6 +250,7 @@ val ownerCarShellRoutes =
         "production-year-input",
         "seats-count-input",
         "trunk-size-selection",
+        "travel-destinations-selection",
         "daily-rate-input",
         "description-input",
         "passport-upload",


### PR DESCRIPTION
## Summary
- Add `travel-destinations-selection` to composeApp owner shell routes (Pages HTML generation).
- Copy all myCarsApp owner routes in github-pages.yml and deploy.yml; assert the new path exists in dist.

## Test plan
- [ ] CI green
- [ ] After merge, `https://dev.drivebit.my/travel-destinations-selection/` returns 200
- [ ] Create-car wizard reaches travel destinations step and car edit can toggle destinations


Made with [Cursor](https://cursor.com)