### PR TITLE
Show travel destinations on car detail

### DIFF
--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DailyRateLabel.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/components/DailyRateLabel.kt
@@ -129,6 +129,43 @@ fun CarInsuranceSection(car: CarDetailResponse) {
 }
 
 @Composable
+fun CarTravelDestinationsSection(car: CarDetailResponse) {
+    val text = car.resolvedTravelDestinationsDisplay() ?: return
+
+    Div({
+        style {
+            marginTop(16.px)
+            padding(16.px, 20.px)
+            property("background-color", CSSColors.WhiteString)
+            property("border-radius", "12px")
+            property("border", "1px solid ${CSSColors.Gray300String}")
+            property("box-sizing", "border-box")
+        }
+    }) {
+        Div({
+            style {
+                fontSize(CSSTypography.FontSize.sm)
+                fontWeight(CSSTypography.FontWeight.medium)
+                color(CSSColors.Black)
+                marginBottom(8.px)
+            }
+        }) {
+            Text("Направления путешествий")
+        }
+        Div({
+            style {
+                fontSize(CSSTypography.FontSize.lg)
+                fontWeight(CSSTypography.FontWeight.normal)
+                color(CSSColors.Black)
+                property("line-height", "1.4")
+            }
+        }) {
+            Text(text)
+        }
+    }
+}
+
+@Composable
 fun CarDepositSection(car: CarDetailResponse) {
     val deposit = car.deposit?.takeIf { it > 0 }?.toInt() ?: return
 

--- a/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarDetailPage.kt
+++ b/DrivebitWeb/src/jsMain/kotlin/my/drivebit/screens/CarDetailPage.kt
@@ -10,6 +10,7 @@ import my.drivebit.components.CarDepositSection
 import my.drivebit.components.CarDescription
 import my.drivebit.components.CarDetailAddress
 import my.drivebit.components.CarInsuranceSection
+import my.drivebit.components.CarTravelDestinationsSection
 import my.drivebit.components.CarLocationMap
 import my.drivebit.components.CarOwnerSection
 import my.drivebit.components.CarPhotosSection
@@ -236,6 +237,8 @@ private fun CarDetailInfoColumn(
         CarDescription(description = car.general.description)
 
         CarInsuranceSection(car)
+
+        CarTravelDestinationsSection(car)
 
         owner?.let { ownerInfo ->
             CarOwnerSection(

--- a/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
+++ b/Network/src/commonMain/kotlin/my/drivebit/network/services/Car.kt
@@ -221,6 +221,13 @@ data class CarDetailResponse(
     fun resolvedAllowedTravelDestinationsTranslate(): List<String> =
         equipment?.allowedTravelDestinationsTranslate.orEmpty()
 
+    fun resolvedTravelDestinationsDisplay(): String? =
+        resolvedAllowedTravelDestinationsTranslate()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(", ")
+
     fun resolvedBrandId(): Int? = brandId
 
     fun resolvedModelId(): Int? = modelId

--- a/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
+++ b/Network/src/commonTest/kotlin/my/drivebit/network/services/CarDetailResponseTest.kt
@@ -323,6 +323,46 @@ class CarDetailResponseTest {
     }
 
     @Test
+    fun `resolvedTravelDestinationsDisplay joins translates with comma`() {
+        val car =
+            CarDetailResponse(
+                id = "x",
+                general =
+                    CarGeneral(
+                        brandName = "A",
+                        modelName = "B",
+                        vin = "",
+                        seats = 5,
+                        address = CarAddress(geoLat = 0.0, geoLon = 0.0),
+                    ),
+                equipment =
+                    CarEquipment(
+                        allowedTravelDestinations = listOf("Belarus", "Abkhazia"),
+                        allowedTravelDestinationsTranslate = listOf("Беларусь", "Абхазия"),
+                    ),
+            )
+        assertEquals("Беларусь, Абхазия", car.resolvedTravelDestinationsDisplay())
+    }
+
+    @Test
+    fun `resolvedTravelDestinationsDisplay is null when destinations are empty`() {
+        val car =
+            CarDetailResponse(
+                id = "x",
+                general =
+                    CarGeneral(
+                        brandName = "A",
+                        modelName = "B",
+                        vin = "",
+                        seats = 5,
+                        address = CarAddress(geoLat = 0.0, geoLon = 0.0),
+                    ),
+                equipment = CarEquipment(),
+            )
+        assertNull(car.resolvedTravelDestinationsDisplay())
+    }
+
+    @Test
     fun `getCar should deserialize equipment allowedTravelDestinations`() =
         runTest {
             val successResponse =


### PR DESCRIPTION
## Summary
- Add `resolvedTravelDestinationsDisplay()` for car detail (joins translated destinations).
- Render «Направления путешествий» section on car detail when destinations are present.

## Test plan
- [x] Unit tests for display helper (join / empty → null)
- [ ] Pages-dev: open car detail with destinations and screenshot section


Made with [Cursor](https://cursor.com)