### PR TITLE
Fix My Cars menu item when account has cars

### DIFF
--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/ButterViewModel.kt
@@ -133,9 +133,7 @@ class ButterViewModelImpl(
 
     override fun open() {
         isMenuOpened = true
-        if (carMenuViewModel.isLoading.value) {
-            carMenuViewModel.load()
-        }
+        carMenuViewModel.load()
         updateMenu(carMenuViewModel.menuOption.value, carMenuViewModel.isLoading.value)
     }
 

--- a/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarMenuViewModel.kt
+++ b/CommonViewModels/src/commonMain/kotlin/my/drivebit/viewmodels/CarMenuViewModel.kt
@@ -50,6 +50,7 @@ class CarMenuViewModelImpl(
         _isLoading.value = true
         coroutineScope.launch {
             runCatching {
+                myCarRepository.refresh()
                 val cars = myCarRepository.getMyCar()
                 _menuOption.value =
                     if (cars.isEmpty()) {

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/ButterViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/ButterViewModelTest.kt
@@ -10,6 +10,7 @@ import my.drivebit.shared.storage.Storage
 import my.drivebit.viewmodels.CarMenuOption
 import my.drivebit.viewmodels.CarMenuViewModel
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -99,13 +100,39 @@ class MockCarMenuViewModelForButter : CarMenuViewModel {
     }
 
     override fun load() {
+        loadCallCount++
     }
+
+    var loadCallCount = 0
 }
 
 class ButterViewModelTest {
     private val mockStorage = MockStorageForButter()
     private val mockAvatarRepository = MockAvatarRepositoryForButter()
     private val mockCarMenuViewModel = MockCarMenuViewModelForButter()
+
+    @Test
+    fun `open should reload car menu option`() {
+        val viewModel = ButterViewModelImpl(mockStorage, mockAvatarRepository, mockCarMenuViewModel)
+
+        viewModel.open()
+
+        assertEquals(2, mockCarMenuViewModel.loadCallCount)
+    }
+
+    @Test
+    fun `open should show MyCars menu item when user has cars`() {
+        mockStorage.setLoggedIn(true)
+        mockCarMenuViewModel.setMenuOption(CarMenuOption.MyCars)
+        mockCarMenuViewModel.setIsLoading(false)
+        val viewModel = ButterViewModelImpl(mockStorage, mockAvatarRepository, mockCarMenuViewModel)
+
+        viewModel.open()
+
+        val openedState = viewModel.state.value as ButterState.Opened
+        assertTrue(openedState.model.any { it.text == "Мои авто" })
+        assertFalse(openedState.model.any { it.text == "Сдать авто" })
+    }
 
     @Test
     fun `initial state should be Idle`() {

--- a/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarMenuViewModelTest.kt
+++ b/CommonViewModels/src/commonTest/kotlin/my/drivebit/viewmodels/CarMenuViewModelTest.kt
@@ -29,15 +29,28 @@ private fun defaultGeneral() =
     )
 
 class MockMyCarRepositoryForMenu : MyCarRepository {
-    private var cars: List<CarItem> = emptyList()
+    private var cachedCars: List<CarItem> = emptyList()
+    private var networkCars: List<CarItem> = emptyList()
+    var refreshCount = 0
 
-    fun setCars(carsList: List<CarItem>) {
-        this.cars = carsList
+    fun setCachedCars(carsList: List<CarItem>) {
+        cachedCars = carsList
     }
 
-    override suspend fun getMyCar(): List<CarItem> = cars
+    fun setNetworkCars(carsList: List<CarItem>) {
+        networkCars = carsList
+    }
 
-    override fun refresh() {}
+    fun setCars(carsList: List<CarItem>) {
+        cachedCars = carsList
+        networkCars = carsList
+    }
+
+    override suspend fun getMyCar(): List<CarItem> = if (refreshCount > 0) networkCars else cachedCars
+
+    override fun refresh() {
+        refreshCount++
+    }
 }
 
 class MockStorageForCarMenu : Storage {
@@ -224,6 +237,31 @@ class CarMenuViewModelTest {
             viewModel.load()
             advanceUntilIdle()
 
+            assertEquals(CarMenuOption.MyCars, viewModel.menuOption.value)
+        }
+
+    @Test
+    fun `should show MyCars when cached list is empty but network has cars`() =
+        runTest(testDispatcher) {
+            mockStorage.setLoggedIn(true)
+            val mockMyCarRepository =
+                MockMyCarRepositoryForMenu().apply {
+                    setCachedCars(emptyList())
+                    setNetworkCars(
+                        listOf(
+                            CarItem(
+                                id = "1",
+                                general = defaultGeneral(),
+                                photos = emptyList(),
+                            ),
+                        ),
+                    )
+                }
+            val viewModel = CarMenuViewModelImpl(mockStorage, mockMyCarRepository, coroutineScope = this)
+            viewModel.load()
+            advanceUntilIdle()
+
+            assertEquals(1, mockMyCarRepository.refreshCount)
             assertEquals(CarMenuOption.MyCars, viewModel.menuOption.value)
         }
 


### PR DESCRIPTION
## Summary
- Refresh `MyCarRepository` before resolving butter menu car option (stale empty cache showed «Сдать авто» after car was added)
- Reload car menu state every time the profile menu opens

## Test plan
- [x] Unit tests for cached-empty/network-nonempty and menu reload on open
- [ ] Log in as account with cars → menu shows «Мои авто» instead of «Сдать авто»


Made with [Cursor](https://cursor.com)